### PR TITLE
Downgrade to graphql 15.8.0 to match express-graphql peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,3 @@ OneService is licensed under the [MIT License](LICENSE).
 © 2022 Superface s.r.o.
 
 <!-- TODO: allcontributors -->
-
-```
-
-```

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.3.2",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",
-    "graphql": "^16.2.0"
+    "graphql": "^15.8.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -8,7 +8,8 @@ Enum description
 enum TestEnum {
   ONE
   TWO
-}"
+}
+"
 `;
 
 exports[`schema.types generateProfileConfig creates config with description and resolve function 1`] = `
@@ -36,7 +37,8 @@ type Scope {
 
 type ScopeProfileTwo {
   UseCase: String
-}"
+}
+"
 `;
 
 exports[`schema.types generateStructureResultType creates ScopeNameResult with description and result field 1`] = `
@@ -59,7 +61,8 @@ type ScopeNameResultNode {
   Named Field description
   \\"\\"\\"
   namedField: String!
-}"
+}
+"
 `;
 
 exports[`schema.types generateUseCaseFieldConfig for profile fixture creates field config with arguments, resolver and description 1`] = `
@@ -89,7 +92,8 @@ input Test {
 enum TestProviderEnum {
   mock
   superface
-}"
+}
+"
 `;
 
 exports[`schema.types inputType returns GraphQLInputType 1`] = `
@@ -141,7 +145,8 @@ Enum description
 enum MyObjectTypeEnum {
   one
   two
-}"
+}
+"
 `;
 
 exports[`schema.types outputType returns GraphQLObjectType 1`] = `
@@ -193,7 +198,8 @@ Enum description
 enum MyObjectTypeEnum {
   one
   two
-}"
+}
+"
 `;
 
 exports[`schema.types scalarType returns GraphQLScalarType 1`] = `
@@ -201,5 +207,6 @@ exports[`schema.types scalarType returns GraphQLScalarType 1`] = `
 Scalar title
 Scalar description
 \\"\\"\\"
-scalar TestScalar"
+scalar TestScalar
+"
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,10 +2338,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
-graphql@^16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.2.0.tgz#de3150e80f1fc009590b92a9d16ab1b46e12b656"
-  integrity sha512-MuQd7XXrdOcmfwuLwC2jNvx0n3rxIuNYOxUtiee5XOmfrWo613ar2U8pE7aHAKh8VwfpifubpD9IP+EdEAEOsA==
+graphql@^15.8.0:
+  version "15.8.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
+  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
 has-flag@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
I have reached GraphQL folks on Discord, and they should be fixing urgent things on graphql projects. So hopefully they will soon get to `express-graphql` as well. Meanwhile I downgraded `graphql` package to supported version by `express-graphql` as we are not using anything from newer versions.

Before:
<img width="999" alt="image" src="https://user-images.githubusercontent.com/959390/148923112-5c1fb18f-b0bc-4981-863f-0495bd635415.png">


After:
<img width="390" alt="image" src="https://user-images.githubusercontent.com/959390/148923147-9f13b7b8-7cfc-411a-97bd-ee0f2e2ccd89.png">