### PR TITLE
feat(graphql): Synchronous createGraphQLMiddleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "graphql": "^15.8.0"
   },
   "devDependencies": {
+    "@jest-mock/express": "^1.4.5",
     "@types/debug": "^4.1.7",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.0.2",

--- a/src/graphql.spec.ts
+++ b/src/graphql.spec.ts
@@ -1,0 +1,49 @@
+import { createGraphQLMiddleware, Middleware } from './graphql';
+import { getMockReq, getMockRes } from '@jest-mock/express';
+
+describe('graphql', () => {
+  describe('createGraphQLMiddleware', () => {
+    describe('with no options', () => {
+      let middleware: Middleware;
+      beforeEach(() => {
+        middleware = createGraphQLMiddleware();
+      });
+      it('returns a middleware with generated schema', () => {
+        expect(middleware).toEqual(expect.any(Function));
+      });
+
+      it('passes initialization error to next', async () => {
+        const req = getMockReq();
+        const { res, next } = getMockRes();
+
+        await expect(middleware(req, res, next)).resolves.not.toThrow();
+        expect(next).toBeCalled();
+      });
+
+      it('throws when next is missing', async () => {
+        const req = getMockReq();
+        const { res } = getMockRes();
+
+        await expect(
+          middleware(req, res),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Unable to generate, super.json not found"`,
+        );
+      });
+    });
+
+    describe('with invalid schema', () => {
+      it('throws an error', async () => {
+        const req = getMockReq();
+        const { res } = getMockRes();
+        // @ts-expect-error Intentional error
+        const middleware = createGraphQLMiddleware({ schema: true });
+        await expect(
+          middleware(req, res),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Property \\"schema\\" is missing"`,
+        );
+      });
+    });
+  });
+});

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -48,16 +48,16 @@ function throwCallback(err: unknown): void {
 export function createGraphQLMiddleware(
   options: CreateGraphQLServerOptions = {},
 ): Middleware {
-  let resolvedMiddleware: Middleware | undefined;
+  const middleware: Promise<Middleware> = createServerOptions(options).then(
+    (options) => graphqlHTTP(options),
+  );
 
   return async function graphqlMiddleware(req, res, next = throwCallback) {
-    if (!resolvedMiddleware) {
-      try {
-        const resolvedOptions = await createServerOptions(options);
-        resolvedMiddleware = graphqlHTTP(resolvedOptions);
-      } catch (err) {
-        return next(err);
-      }
+    let resolvedMiddleware: Middleware;
+    try {
+      resolvedMiddleware = await middleware;
+    } catch (err) {
+      return next(err);
     }
     return resolvedMiddleware(req, res);
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ export async function bootstrap(config: Configuration): Promise<Express> {
   const app = express();
   const httpServer = http.createServer(app);
 
-  const gqlServer = await createGraphQLMiddleware(config);
+  const gqlServer = createGraphQLMiddleware(config);
   app.use('/graphql', gqlServer);
 
   const host = config.host ?? HOST;

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,6 +343,11 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@jest-mock/express@^1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@jest-mock/express/-/express-1.4.5.tgz#437db24ccd505d88f8c0d73e8593fa3cd6eb273b"
+  integrity sha512-bERM1jnutyH7VMahdaOHAKy7lgX47zJ7+RTz2eMz0wlCttd9CkhsKFEyoWmJBSz/ow0nVj3lCuRqLem4QDYFkQ==
+
 "@jest/console@^27.4.6":
   version "27.4.6"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.4.6.tgz#0742e6787f682b22bdad56f9db2a8a77f6a86107"


### PR DESCRIPTION
Currently `createGraphQLMiddleware` is async, which means a promise is passed to `use` when mounting the middleware.

This is non-standard for middlewares and can cause problems with other Express-compatible servers like Polka.

This is my attempt to make `createGraphQLMiddleware` synchronous. I have also kicked off some specs for graphql.