### PR TITLE
chore(spec): Add spec for createGraphQLMiddleware

### DIFF
--- a/src/graphql.spec.ts
+++ b/src/graphql.spec.ts
@@ -16,8 +16,7 @@ describe('graphql', () => {
   describe('createGraphQLMiddleware', () => {
     describe('with no options', () => {
       it('returns a middleware with generated schema', async () => {
-        const middleware = createGraphQLMiddleware();
-        expect(middleware).resolves.toEqual(expect.any(Function));
+        await expect(createGraphQLMiddleware()).resolves.toEqual(expect.any(Function));
         expect(createSchema).toHaveBeenCalled();
       });
 

--- a/src/graphql.spec.ts
+++ b/src/graphql.spec.ts
@@ -28,7 +28,7 @@ describe('graphql', () => {
         });
 
         it('throws upon initialization', async () => {
-          expect(createGraphQLMiddleware()).rejects.toThrowError();
+          await expect(createGraphQLMiddleware()).rejects.toThrowError();
         });
       });
     });

--- a/src/graphql.spec.ts
+++ b/src/graphql.spec.ts
@@ -1,0 +1,47 @@
+import { createGraphQLMiddleware } from './graphql';
+import { createSchema } from './schema';
+import { mocked } from 'jest-mock';
+import { GraphQLSchema } from 'graphql';
+
+jest.mock('./schema');
+
+describe('graphql', () => {
+  beforeEach(() => {
+    mocked(createSchema).mockResolvedValue(new GraphQLSchema({}));
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('createGraphQLMiddleware', () => {
+    describe('with no options', () => {
+      it('returns a middleware with generated schema', async () => {
+        const middleware = createGraphQLMiddleware();
+        expect(middleware).resolves.toEqual(expect.any(Function));
+        expect(createSchema).toHaveBeenCalled();
+      });
+
+      describe('with createSchema error', () => {
+        beforeEach(() => {
+          mocked(createSchema).mockRejectedValueOnce(
+            new Error('Unable to generate, super.json not found'),
+          );
+        });
+
+        it('throws upon initialization', async () => {
+          expect(createGraphQLMiddleware()).rejects.toThrowError();
+        });
+      });
+    });
+
+    describe('with invalid schema', () => {
+      it('throws an error', async () => {
+        // @ts-expect-error Intentional error
+        const middleware = createGraphQLMiddleware({ schema: true });
+        await expect(middleware).rejects.toThrowErrorMatchingInlineSnapshot(
+          `"Property \\"schema\\" is missing"`,
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Salvaged from #11, just calling of `createGraphQLMiddleware` and some error states.

Closes #11