### PR TITLE
chore(package): Add prepack script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Tests
         run: yarn test
 
-      # Build the project
-      - name: Build
-        run: yarn build
-
       # Git configuration
       - name: Git configuration
         run: |

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "format": "prettier -c src/",
     "format:fix": "prettier --write src/",
     "start": "./bin/cli",
-    "start:dev": "nodemon --exec 'ts-node' src/cli.ts"
+    "start:dev": "nodemon --exec 'ts-node' src/cli.ts",
+    "prepack": "yarn build"
   },
   "dependencies": {
     "@superfaceai/ast": "^1.0.0",


### PR DESCRIPTION
The motivation here is to be able to use the package stright from GitHub. (Not sure how yarn handles it but [npm's prepack](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts) is explicitly ran when installing git dependencies).

I have also removed the `build` step in the release flow to avoid running `tsc` twice.