### PR TITLE
Update and pin OneSDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Updated and pin OneSDK to 1.5.1
+- Removed explicit dependency on AST and Parser
+
 ## 1.0.0-rc.3 - 2022-05-31
 ### Added
 - Graceful shutdown

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
     "prepack": "yarn build"
   },
   "dependencies": {
-    "@superfaceai/ast": "^1.2.0",
     "@superfaceai/one-sdk": "1.5.1",
-    "@superfaceai/parser": "^1.2.0",
     "@superfaceai/service-client": "^3.0.0",
     "commander": "^9.0.0",
     "debug": "^4.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@superfaceai/ast": "^1.2.0",
-    "@superfaceai/one-sdk": "^1.4.1",
+    "@superfaceai/one-sdk": "1.5.1",
     "@superfaceai/parser": "^1.2.0",
     "@superfaceai/service-client": "^3.0.0",
     "commander": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -584,7 +584,7 @@
     isomorphic-form-data "^2.0.0"
     vm2 "^3.9.7"
 
-"@superfaceai/parser@1.2.0", "@superfaceai/parser@^1.2.0":
+"@superfaceai/parser@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@superfaceai/parser/-/parser-1.2.0.tgz#e89e64c9ec98ff2d1e4760c1441d88d945978a1d"
   integrity sha512-8nQ4x15F8mygKg4BcWwzqgDVTaY5BXanvCcxirL/jKLgpGUxH+808t0KmVc2Ke9o2MdiYt/2UD2hyfpwwqN9DA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,10 +571,10 @@
     ajv "^8.8.2"
     ajv-formats "^2.1.1"
 
-"@superfaceai/one-sdk@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-1.4.1.tgz#9ca9e4921f2888efa9d64b404520853ce28debee"
-  integrity sha512-4G49129CAyiaucRaETi5WlghZo7+aAboiq1nWmKCLQCcxEaTteWbJnn1P1USFiIuERJZvxQpx6cohChbxfzbbg==
+"@superfaceai/one-sdk@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-1.5.1.tgz#772a094a06b56865ca42a4f120bad783ea8098c4"
+  integrity sha512-yJRl/DRXJFGZtXfe5jeW4QROoVG/2hrrLBrz9sJAQKvv/38W1xfDx0M2inikgz/0yTmMaYTaYJH29fDLRceVVg==
   dependencies:
     "@superfaceai/ast" "1.2.0"
     "@superfaceai/parser" "1.2.0"


### PR DESCRIPTION
- Updated and pin OneSDK to 1.5.1
- Removed explicit dependency on AST and Parser


@Jakub-Vacek as you suggested this locking in [PR18](https://github.com/superfaceai/one-service/pull/18#discussion_r884788024). I gave it some thoughts and I believe you were right and it is good idea.