### PR TITLE
feat: Map OneSDK errors to be GraphQL-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Return correctly structured error from the resolver (#24)
 
 ## [1.0.0] - 2022-06-16
 ### Changed

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -45,9 +45,6 @@ describe('errors', () => {
         response: {
           body: 'foo',
         },
-        metadata: {
-          foo: 'bar',
-        },
       };
 
       const result = remapOneSdkError({
@@ -63,11 +60,16 @@ describe('errors', () => {
         message: 'Message',
         name: 'Error',
         foo: 'bar',
+        metadata: {
+          foo: 'bar',
+        },
       };
 
       const result = remapOneSdkError(input);
       expect(result).not.toHaveProperty('foo');
+      expect(result).not.toHaveProperty('metadata');
       expect(result.extensions).not.toHaveProperty('foo');
+      expect(result.extensions).not.toHaveProperty('metadata');
     });
   });
 });

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,13 +1,20 @@
+import {
+  ErrorBase,
+  JessieError,
+  MappedError,
+  MappedHTTPError,
+  SDKExecutionError,
+} from '@superfaceai/one-sdk';
 import { isOneSdkError, remapOneSdkError } from './errors';
 
 describe('errors', () => {
   describe('isOneSdkError', () => {
-    it('accepts any object with message property', () => {
-      expect(isOneSdkError({ message: 'foo' })).toBe(true);
+    it("doesn't accept a plain object", () => {
+      expect(isOneSdkError({ message: 'foo' })).toBe(false);
     });
 
-    it('accepts an Error object', () => {
-      expect(isOneSdkError(new Error('bar'))).toBe(true);
+    it("doesn't accept an Error object", () => {
+      expect(isOneSdkError(new Error('bar'))).toBe(false);
     });
 
     it("doesn't accept null", () => {
@@ -17,6 +24,26 @@ describe('errors', () => {
     it("doesn't accept anything else", () => {
       expect(isOneSdkError(['baz'])).toBe(false);
       expect(isOneSdkError('foobar')).toBe(false);
+    });
+
+    it('accepts ErrorBase', () => {
+      expect(isOneSdkError(new ErrorBase('Foo', 'Bar'))).toBe(true);
+    });
+
+    it('accepts SDKExecutionError', () => {
+      expect(isOneSdkError(new SDKExecutionError('Foo', [], []))).toBe(true);
+    });
+
+    it('accepts MappedHTTPError', () => {
+      expect(isOneSdkError(new MappedHTTPError('foo', 200))).toBe(true);
+    });
+
+    it('accepts MappedError', () => {
+      expect(isOneSdkError(new MappedError('foo'))).toBe(true);
+    });
+
+    it('accepts JessieError', () => {
+      expect(isOneSdkError(new JessieError('foo', new Error()))).toBe(true);
     });
   });
 

--- a/src/errors.spec.ts
+++ b/src/errors.spec.ts
@@ -1,0 +1,73 @@
+import { isOneSdkError, remapOneSdkError } from './errors';
+
+describe('errors', () => {
+  describe('isOneSdkError', () => {
+    it('accepts any object with message property', () => {
+      expect(isOneSdkError({ message: 'foo' })).toBe(true);
+    });
+
+    it('accepts an Error object', () => {
+      expect(isOneSdkError(new Error('bar'))).toBe(true);
+    });
+
+    it("doesn't accept null", () => {
+      expect(isOneSdkError(null)).toBe(false);
+    });
+
+    it("doesn't accept anything else", () => {
+      expect(isOneSdkError(['baz'])).toBe(false);
+      expect(isOneSdkError('foobar')).toBe(false);
+    });
+  });
+
+  describe('remapOneSdkError', () => {
+    it('wraps object to Error', () => {
+      expect(
+        remapOneSdkError({ name: 'FooBar', message: 'Some message' }),
+      ).toBeInstanceOf(Error);
+    });
+
+    it('keeps originalError in a property', () => {
+      const input = { name: 'FooBar', message: 'Some message' };
+      const result = remapOneSdkError(input);
+      expect(result.message).toBe(input.message);
+      expect(result.originalError).toEqual(input);
+    });
+
+    it('copies over selected properties from the input', () => {
+      const extensions = {
+        kind: 'Kind',
+        properties: {
+          foo: true,
+          bar: ['baz'],
+        },
+        statusCode: '200',
+        response: {
+          body: 'foo',
+        },
+        metadata: {
+          foo: 'bar',
+        },
+      };
+
+      const result = remapOneSdkError({
+        message: 'Message',
+        name: 'Error',
+        ...extensions,
+      });
+      expect(result.extensions).toEqual(extensions);
+    });
+
+    it('ignores other properties from the input error', () => {
+      const input = {
+        message: 'Message',
+        name: 'Error',
+        foo: 'bar',
+      };
+
+      const result = remapOneSdkError(input);
+      expect(result).not.toHaveProperty('foo');
+      expect(result.extensions).not.toHaveProperty('foo');
+    });
+  });
+});

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,6 @@
 interface ErrorExtensions {
   properties?: Record<string, unknown>;
   statusCode?: string;
-  metadata?: Record<string, unknown>;
   response?: Record<string, unknown>;
   kind?: string;
 }
@@ -26,7 +25,6 @@ export function remapOneSdkError(originalError: OneSdkError): WrappedError {
     properties: originalError.properties,
     statusCode: originalError.statusCode,
     response: originalError.response,
-    metadata: originalError.metadata,
   };
 
   return error;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,5 @@
+import { ErrorBase, SDKExecutionError } from '@superfaceai/one-sdk';
+
 interface ErrorExtensions {
   properties?: Record<string, unknown>;
   statusCode?: string;
@@ -7,18 +9,20 @@ interface ErrorExtensions {
 
 export interface OneSdkError extends ErrorExtensions, Error {}
 
-interface WrappedError extends Error {
+export interface OneSdkResolverError extends Error {
   originalError?: unknown;
   extensions?: ErrorExtensions;
 }
 
-export function isOneSdkError(err: unknown): err is OneSdkError {
-  return typeof err === 'object' && err != null && 'message' in err;
+export function isOneSdkError(error: unknown): error is OneSdkError {
+  return error instanceof ErrorBase || error instanceof SDKExecutionError;
 }
 
-export function remapOneSdkError(originalError: OneSdkError): WrappedError {
+export function remapOneSdkError(
+  originalError: OneSdkError,
+): OneSdkResolverError {
   const message = originalError.message || 'Unknown OneSDK Error';
-  const error: WrappedError = new Error(message);
+  const error: OneSdkResolverError = new Error(message);
   error.originalError = originalError;
   error.extensions = {
     kind: originalError.kind,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,9 +1,4 @@
-interface WrappedError extends Error {
-  originalError?: unknown;
-  extensions?: Record<string, unknown>;
-}
-
-export interface OneSdkError extends Error {
+interface ErrorExtensions {
   properties?: Record<string, unknown>;
   statusCode?: string;
   metadata?: Record<string, unknown>;
@@ -11,8 +6,19 @@ export interface OneSdkError extends Error {
   kind?: string;
 }
 
-export function remapSdkError(originalError: OneSdkError): WrappedError {
-  const message = (originalError as Error)?.message || 'Unknown OneSDK Error';
+export interface OneSdkError extends ErrorExtensions, Error {}
+
+interface WrappedError extends Error {
+  originalError?: unknown;
+  extensions?: ErrorExtensions;
+}
+
+export function isOneSdkError(err: unknown): err is OneSdkError {
+  return typeof err === 'object' && err != null && 'message' in err;
+}
+
+export function remapOneSdkError(originalError: OneSdkError): WrappedError {
+  const message = originalError.message || 'Unknown OneSDK Error';
   const error: WrappedError = new Error(message);
   error.originalError = originalError;
   error.extensions = {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,27 @@
+interface WrappedError extends Error {
+  originalError?: unknown;
+  extensions?: Record<string, unknown>;
+}
+
+export interface OneSdkError extends Error {
+  properties?: Record<string, unknown>;
+  statusCode?: string;
+  metadata?: Record<string, unknown>;
+  response?: Record<string, unknown>;
+  kind?: string;
+}
+
+export function remapSdkError(originalError: OneSdkError): WrappedError {
+  const message = (originalError as Error)?.message || 'Unknown OneSDK Error';
+  const error: WrappedError = new Error(message);
+  error.originalError = originalError;
+  error.extensions = {
+    kind: originalError.kind,
+    properties: originalError.properties,
+    statusCode: originalError.statusCode,
+    response: originalError.response,
+    metadata: originalError.metadata,
+  };
+
+  return error;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ const packageJson = require('../package.json');
 export * from './server';
 export * from './graphql';
 export * from './schema';
+export { OneSdkResolverError } from './errors';
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
 export const VERSION: string = packageJson.version;

--- a/src/one_sdk.ts
+++ b/src/one_sdk.ts
@@ -2,7 +2,7 @@ import { Provider, SuperfaceClient } from '@superfaceai/one-sdk';
 import createDebug from 'debug';
 import { GraphQLFieldResolver } from 'graphql';
 import { DEBUG_PREFIX } from './constants';
-import { OneSdkError, remapSdkError } from './errors';
+import { isOneSdkError, OneSdkError, remapOneSdkError } from './errors';
 
 const debug = createDebug(`${DEBUG_PREFIX}:onesdk`);
 let instance: SuperfaceClient;
@@ -76,7 +76,10 @@ export function createResolver(
       // This is needed because OneSDK v1.x throws errors which don't inherit from Error,
       // causing graphql-js to throw the original error away.
       // While we do mapping, we can also extract SDK-specific properties to GraphQL extensions
-      throw remapSdkError(err as OneSdkError);
+      if (isOneSdkError(err)) {
+        throw remapOneSdkError(err);
+      }
+      throw err;
     }
   };
 }

--- a/src/one_sdk.ts
+++ b/src/one_sdk.ts
@@ -2,7 +2,7 @@ import { Provider, SuperfaceClient } from '@superfaceai/one-sdk';
 import createDebug from 'debug';
 import { GraphQLFieldResolver } from 'graphql';
 import { DEBUG_PREFIX } from './constants';
-import { isOneSdkError, OneSdkError, remapOneSdkError } from './errors';
+import { isOneSdkError, remapOneSdkError } from './errors';
 
 const debug = createDebug(`${DEBUG_PREFIX}:onesdk`);
 let instance: SuperfaceClient;

--- a/src/one_sdk.ts
+++ b/src/one_sdk.ts
@@ -2,6 +2,7 @@ import { Provider, SuperfaceClient } from '@superfaceai/one-sdk';
 import createDebug from 'debug';
 import { GraphQLFieldResolver } from 'graphql';
 import { DEBUG_PREFIX } from './constants';
+import { OneSdkError, remapSdkError } from './errors';
 
 const debug = createDebug(`${DEBUG_PREFIX}:onesdk`);
 let instance: SuperfaceClient;
@@ -72,7 +73,10 @@ export function createResolver(
       }
     } catch (err) {
       debug('Perform exception', err);
-      throw err;
+      // This is needed because OneSDK v1.x throws errors which don't inherit from Error,
+      // causing graphql-js to throw the original error away.
+      // While we do mapping, we can also extract SDK-specific properties to GraphQL extensions
+      throw remapSdkError(err as OneSdkError);
     }
   };
 }


### PR DESCRIPTION
Fixes #24.

The root cause of this issue is that OneSDK sometimes throws errors which don't inherit JS's `Error` object, causing the `Unexpected error value` seen in #24.

Here I have added a custom error wrapper which remaps OneSDK errors to extended Error object. graphql-js automatically picks `extensions` property and propagates it further, resulting more detailed output:

![image](https://user-images.githubusercontent.com/616767/182383874-befb463f-ef4a-4da6-8270-7c9eb338b372.png)

Additionally users can provide their custom `customFormatErrorFn` to expose information they need.

## Todo

- [x] Tests
- [x] Should we pass-on `metadata` by default? Seems like unnecessary noise (and can be accessed in `originalError` from the formatter).