### PR TITLE
Input may be skipped in GQL, but needed for perform

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           RELEASE_LEVEL: ${{ github.event.inputs.release-level }}
 
       - name: Bump pre-release version
-        if: startsWith(github.event.inputs.release-level, 'pre') && github.ref_name != 'dev'
+        if: startsWith(github.event.inputs.release-level, 'pre') && github.ref_name != 'main'
         run: |
           echo "NEW_VERSION=$(npm --no-git-tag-version --preid=beta version $RELEASE_LEVEL)" >> $GITHUB_ENV
           echo "RELEASE_TAG=beta" >> $GITHUB_ENV
@@ -50,7 +50,7 @@ jobs:
           RELEASE_LEVEL: ${{ github.event.inputs.release-level }}
 
       - name: Bump rc pre-release version
-        if: startsWith(github.event.inputs.release-level, 'pre') && github.ref_name == 'dev'
+        if: startsWith(github.event.inputs.release-level, 'pre') && github.ref_name == 'main'
         run: |
           echo "NEW_VERSION=$(npm --no-git-tag-version --preid=rc version $RELEASE_LEVEL)" >> $GITHUB_ENV
           echo "RELEASE_TAG=next" >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handle not specified input in GQL query - [#29](https://github.com/superfaceai/one-service/pull/29)
 
 ## [2.0.2] - 2023-02-08
 

--- a/src/one_sdk.spec.ts
+++ b/src/one_sdk.spec.ts
@@ -11,7 +11,10 @@ import {
 const { Ok, Err } = jest.requireActual('@superfaceai/one-sdk');
 
 async function callResolver(
-  args: { input?: Record<string, any>; options?: { provider?: string } },
+  args: {
+    input?: Record<string, any>;
+    options?: { provider?: string; parameters?: Record<string, string> };
+  },
   profile = 'profile',
   useCase = 'UseCase',
 ) {
@@ -98,6 +101,26 @@ describe('one_sdk', () => {
 
   describe('createResolver', () => {
     let resolverResult: any;
+
+    it('sets empty object if input is not set', async () => {
+      performMock.mockResolvedValue(new Ok('perform result'));
+      await callResolver({
+        input: undefined,
+      });
+
+      expect(performMock.mock.calls[0][0]).toEqual({});
+    });
+
+    it('sets empty object if parameters are not set', async () => {
+      performMock.mockResolvedValue(new Ok('perform result'));
+      await callResolver({
+        options: {
+          parameters: undefined,
+        },
+      });
+
+      expect(performMock.mock.calls[0][1]['parameters']).toEqual({});
+    });
 
     describe('perform returns Ok result', () => {
       beforeEach(async () => {

--- a/src/one_sdk.ts
+++ b/src/one_sdk.ts
@@ -57,9 +57,9 @@ export function createResolver(
       const result = await perform({
         profile,
         useCase,
-        input: args?.input,
+        input: args?.input ?? {},
         provider: args?.options?.provider,
-        parameters: args?.options?.parameters,
+        parameters: args?.options?.parameters ?? {},
       });
 
       debug('Perform result', result);
@@ -73,7 +73,7 @@ export function createResolver(
       }
     } catch (err) {
       debug('Perform exception', err);
-      // This is needed because OneSDK v1.x throws errors which don't inherit from Error,
+      // This is needed because OneSDK throws errors which don't inherit from Error,
       // causing graphql-js to throw the original error away.
       // While we do mapping, we can also extract SDK-specific properties to GraphQL extensions
       if (isOneSdkError(err)) {


### PR DESCRIPTION
This will fallback to `{}` empty object if input isn't specified.