### PR TITLE
chore: Update OneSDK to v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update OneSDK to v2.3.1 ([#30](https://github.com/superfaceai/one-service/pull/30))
 
 ## [2.0.3] - 2023-02-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Update OneSDK to v2.3.1 ([#30](https://github.com/superfaceai/one-service/pull/30))
+- Update OneSDK to v2.3.1 - [#30](https://github.com/superfaceai/one-service/pull/30)
 
 ## [2.0.3] - 2023-02-15
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@superfaceai/ast": "^1.3.0",
-    "@superfaceai/one-sdk": "^2.3.0",
+    "@superfaceai/one-sdk": "^2.3.1",
     "@superfaceai/parser": "^2.1.0",
     "commander": "^9.4.1",
     "debug": "^4.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,10 +849,10 @@
     ajv "^8.8.2"
     ajv-formats "^2.1.1"
 
-"@superfaceai/one-sdk@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-2.3.0.tgz#7de9de084f8e69dc7fefe0a9b1e7d6abb3a69be7"
-  integrity sha512-6B2EdxE//vkri9ZBv6f8fHMoItCDoCO7XqbNBqpcYAsm3wj+8B7vC7eWRhN1+z6YPww1VzFLFmorF9UMc7jRdg==
+"@superfaceai/one-sdk@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-2.3.1.tgz#7856156662a9a14b18df0efe9516e219638f094e"
+  integrity sha512-vko9BmqpBVuFvPk15vS9zAjtTm5VdQPKBzMHRnHHasA2UfEwkWhURg7dPRLLVn9FTNdDnHzkcIbMtbbMNBb8qA==
   dependencies:
     "@superfaceai/ast" "1.3.0"
     abort-controller "^3.0.0"


### PR DESCRIPTION
Explicitly bump OneSDK dependency to v2. 3.1. Although the patch version is covered by semver range, v2.3.0 contains a bug which is triggered by the GraphQL resolver, therefore the previous version shouldn't be used with OneService at all.

Refs: https://github.com/superfaceai/one-sdk-js/pull/333