### PR TITLE
Allow to pass `getOneSdkInstance` in context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ yarn-error.log*
 
 dist
 superface
+workdir/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `createGraphQLMiddleware` accepts context agument with `getOneSdkInstance` to allow own OneSDK instances - [#32](https://github.com/superfaceai/one-service/pull/32)
 
 ## [2.1.0] - 2023-02-16
 ### Changed

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@superfaceai/ast": "^1.3.0",
-    "@superfaceai/one-sdk": "^2.3.1",
+    "@superfaceai/one-sdk": "^2.4.1",
     "@superfaceai/parser": "^2.1.0",
     "commander": "^10.0.0",
     "debug": "^4.3.4",

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,8 +1,9 @@
 import { createHandler, HandlerOptions } from 'graphql-http/lib/use/express';
 import { Handler } from 'express';
 import { createSchema } from './schema';
+import { ResolverContext } from './one_sdk';
 
-export type CreateGraphQLServerOptions = HandlerOptions;
+export type CreateGraphQLServerOptions = HandlerOptions<ResolverContext>;
 
 export async function createGraphQLMiddleware(
   options: CreateGraphQLServerOptions = {},

--- a/src/one_sdk.ts
+++ b/src/one_sdk.ts
@@ -1,25 +1,26 @@
 import { Provider, SuperfaceClient } from '@superfaceai/one-sdk';
 import createDebug from 'debug';
-import { GraphQLFieldResolver } from 'graphql';
+import { GraphQLFieldResolver, GraphQLResolveInfo } from 'graphql';
 import { DEBUG_PREFIX } from './constants';
 import { isOneSdkError, remapOneSdkError } from './errors';
 
 const debug = createDebug(`${DEBUG_PREFIX}:onesdk`);
 let instance: SuperfaceClient;
 
-export interface PerformParams {
+export type PerformParams = {
   profile: string;
   useCase: string;
+  input: Record<string, any>;
   provider?: string;
   parameters?: Record<string, string>;
-  input: Record<string, any>;
-}
+  oneSdk?: SuperfaceClient;
+};
 
 export function createInstance() {
   return new SuperfaceClient();
 }
 
-export function getInstance(): SuperfaceClient {
+export function getInstance() {
   if (!instance) {
     instance = createInstance();
   }
@@ -28,7 +29,7 @@ export function getInstance(): SuperfaceClient {
 }
 
 export async function perform(params: PerformParams) {
-  const oneSdk = getInstance();
+  const oneSdk = params.oneSdk ?? getInstance();
 
   const profile = await oneSdk.getProfile(params.profile);
   const useCase = profile.getUseCase(params.useCase);
@@ -44,29 +45,59 @@ export async function perform(params: PerformParams) {
   });
 }
 
-export function createResolver(
+export type ResolverContext = {
+  getOneSdkInstance?: () => SuperfaceClient;
+};
+export type ResolverArgs = {
+  input?: PerformParams['input'];
+  options?: {
+    provider?: PerformParams['provider'];
+    parameters?: PerformParams['parameters'];
+  };
+};
+export type ResolverResult<TResult> = {
+  result: TResult;
+};
+
+export function createResolver<
+  TSource,
+  TContext extends ResolverContext,
+  TArgs extends ResolverArgs,
+  TResult = unknown,
+>(
   profile: string,
   useCase: string,
-): GraphQLFieldResolver<any, any> {
+): GraphQLFieldResolver<
+  TSource,
+  TContext,
+  TArgs,
+  Promise<ResolverResult<TResult>>
+> {
   debug(`Creating resolver for ${profile}/${useCase}`);
 
-  return async function oneSdkResolver(source: any, args: any): Promise<any> {
-    debug(`Performing ${profile}/${useCase}`, { source, args });
+  return async function oneSdkResolver(
+    source: TSource,
+    args: TArgs,
+    context: TContext | undefined,
+    info: GraphQLResolveInfo,
+  ): Promise<ResolverResult<TResult>> {
+    debug(`Performing ${profile}/${useCase}`, { source, args, context, info });
 
     try {
       const result = await perform({
         profile,
         useCase,
-        input: args?.input ?? {},
-        provider: args?.options?.provider,
-        parameters: args?.options?.parameters ?? {},
+        input: args.input ?? {},
+        provider: args.options?.provider,
+        parameters: args.options?.parameters ?? {},
+        oneSdk: context?.getOneSdkInstance?.(),
       });
 
       debug('Perform result', result);
 
       if (result.isOk()) {
         return {
-          result: result.value,
+          result: result.value as TResult,
         };
       } else {
         throw result.error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -861,10 +861,10 @@
     ajv "^8.8.2"
     ajv-formats "^2.1.1"
 
-"@superfaceai/one-sdk@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-2.3.1.tgz#7856156662a9a14b18df0efe9516e219638f094e"
-  integrity sha512-vko9BmqpBVuFvPk15vS9zAjtTm5VdQPKBzMHRnHHasA2UfEwkWhURg7dPRLLVn9FTNdDnHzkcIbMtbbMNBb8qA==
+"@superfaceai/one-sdk@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-2.4.1.tgz#8b713fca26d1e2883d4b51b3ded9f6512ca11305"
+  integrity sha512-BhO2AXd5sR3eJXG/9oQMrchrs20JzUBjS4j/3K9+hOSrhW8DyqmoBzquAUDzSHPs0vrR/MFR1YYYhTBPEDwxwA==
   dependencies:
     "@superfaceai/ast" "1.3.0"
     abort-controller "^3.0.0"


### PR DESCRIPTION
Example use with dynamic schema and OneSDK configuration:

```ts
import { SuperJsonDocument } from '@superfaceai/ast';
import {
  normalizeSuperJsonDocument,
  SuperfaceClient,
} from '@superfaceai/one-sdk';
import express, { Handler } from 'express';
import { createGraphQLMiddleware } from '../graphql';
import { generate as generateSchema } from '../schema';
import superOne from './super_one.json';
import superTwo from './super_two.json';

const superjsons: Record<string, SuperJsonDocument> = {
  one: superOne as unknown as SuperJsonDocument,
  two: superTwo as unknown as SuperJsonDocument,
};

const handlers: Record<string, Handler> = {};

async function getHandler(id: string): Promise<Handler> {
  if (!handlers[id]) {
    const superJson = normalizeSuperJsonDocument(superjsons[id]);
    const schema = await generateSchema(superJson);

    handlers[id] = await createGraphQLMiddleware({
      schema,
      context: {
        getOneSdkInstance() {
          return new SuperfaceClient({ superJson });
        },
      },
    });
  }

  return handlers[id];
}

async function main() {
  const app = express();

  app.use('/graphql', async (req, res, next) => {
    const id = req.query.id;

    if (!superjsons[String(id)]) {
      res.status(400).json({ message: `Invalid id '${id}'` });

      return;
    }

    const handler = await getHandler(String(id));

    handler(req, res, next);
  });

  await new Promise<void>((resolve) => app.listen(8000, '127.0.0.1', resolve));

  console.log(`🚀 Server ready at http://127.0.0.1:8000`);
  console.log('      GraphQL endpoint /graphql');
}

void main();
```