### PR TITLE
fix(graphiql): Specify ext. dependencies version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `createGraphQLMiddleware` accepts context agument with `getOneSdkInstance` to allow own OneSDK instances - [#32](https://github.com/superfaceai/one-service/pull/32)
 
+### Fixed
+- Pin GraphiQL to specific version (v2.4.0) to prevent breakage due to incorrect integrity check - [#34](https://github.com/superfaceai/one-service/pull/34)
+
 ## [2.1.0] - 2023-02-16
 ### Changed
 - Replaced `express-graphql` with `graphql-http` - [#31](https://github.com/superfaceai/one-service/pull/31)

--- a/src/graphiql.ts
+++ b/src/graphiql.ts
@@ -45,7 +45,7 @@ export function renderGraphiQL(_req: Request, res: Response): void {
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://unpkg.com/@graphiql/plugin-explorer@0.1.12/dist/graphiql-plugin-explorer.umd.js"
+      src="https://unpkg.com/@graphiql/plugin-explorer@0.1.14/dist/graphiql-plugin-explorer.umd.js"
       integrity="sha384-rbN7vYh67VVbUGRkgCVTFu0Pk25KR5Ns9b6sOyPHf5GiYat1ce44UEF5I+HqE2Dg"
       crossorigin="anonymous"
     ></script>

--- a/src/graphiql.ts
+++ b/src/graphiql.ts
@@ -19,10 +19,10 @@ export function renderGraphiQL(_req: Request, res: Response): void {
       }
     </style>
 
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@2.4.0/graphiql.min.css" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
+      href="https://unpkg.com/@graphiql/plugin-explorer@0.1.14/dist/style.css"
     />
   </head>
 
@@ -40,8 +40,8 @@ export function renderGraphiQL(_req: Request, res: Response): void {
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://unpkg.com/graphiql/graphiql.min.js"
-      integrity="sha384-JHFGCFTH/jUGV6uL38eHuw/3kb0aUiF0EzWPP68NQxvz7ldZXEoCv9RBGtsFHM86"
+      src="https://unpkg.com/graphiql@2.4.0/graphiql.min.js"
+      integrity="sha384-MVcRONLrOPBea05C9lB5pu31zTbPkbZI/gIn2y0r5xH6GefRkJcnrBGlY4zo2nwC"
       crossorigin="anonymous"
     ></script>
     <script


### PR DESCRIPTION
GraphiQL recently released v2.4.0, however page links to the latest version from unpkg with an integrity check.

Integrity check with newer version of GraphiQL fails and the page won't load at all.

This sets the version of GraphiQL to v2.4.0 with appropriate integrity check.