### PR TITLE
Generate _superJson introspection schema and resolver using SuperJson document from argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- generate _superJson introspection schema and resolver with SuperJson document from argument instead of loading it from file system 
+
 ## [2.2.1] - 2023-03-07
 ### Fixed
 - CLI port option validation with custom validation function Issue [#35](https://github.com/superfaceai/one-service/issues/35) - [#37](https://github.com/superfaceai/one-service/pull/37)

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -94,7 +94,7 @@ export async function generate(
     }
   }
 
-  queryFields['_superJson'] = superJsonFieldConfig();
+  queryFields['_superJson'] = superJsonFieldConfig(superJson);
 
   const schema = new GraphQLSchema({
     description: 'Superface.ai ❤️',
@@ -117,7 +117,9 @@ export async function generate(
   return schema;
 }
 
-export function superJsonFieldConfig(): GraphQLFieldConfig<any, any> {
+export function superJsonFieldConfig(
+  superJsonDocument?: NormalizedSuperJsonDocument,
+): GraphQLFieldConfig<any, any> {
   return {
     type: new GraphQLObjectType({
       name: 'SuperJson',
@@ -146,7 +148,7 @@ export function superJsonFieldConfig(): GraphQLFieldConfig<any, any> {
       },
     }),
     resolve: async () => {
-      const superJson = await loadSuperJson();
+      const superJson = superJsonDocument ?? (await loadSuperJson());
       const anonymizedSuperJson = anonymizeSuperJson(superJson);
 
       return {


### PR DESCRIPTION
This PR fixes generating of _superJson introspection schema and resolver. Instead of loading it from file system it uses `SuperJsonDocument` passed from argument.