### PR TITLE
Fix generating schema for empty input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- generate schema when use case contains empty input fields without input argument
 
 ## [2.2.2] - 2023-03-09
 ### Fixed

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -80,6 +80,20 @@ UseCase description",
 }
 `;
 
+exports[`schema.types generateUseCaseFieldConfig for profile fixture with empty input fields creates arguments without input 1`] = `
+{
+  "args": {
+    "options": {
+      "type": "ScopeNameUseCaseOptions",
+    },
+  },
+  "description": "UseCase
+UseCase description",
+  "resolve": [Function],
+  "type": "ScopeNameUseCaseResult",
+}
+`;
+
 exports[`schema.types generateUseCaseOptionsInputType creates input with providers enum and input parameters 1`] = `
 """"Additional options to pass to OneSDK perform function"""
 input Test {

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -87,8 +87,7 @@ exports[`schema.types generateUseCaseFieldConfig for profile fixture with empty 
       "type": "ScopeNameUseCaseOptions",
     },
   },
-  "description": "UseCase
-UseCase description",
+  "description": undefined,
   "resolve": [Function],
   "type": "ScopeNameUseCaseResult",
 }

--- a/src/fixtures/profile_with_empty_input_structure.supr
+++ b/src/fixtures/profile_with_empty_input_structure.supr
@@ -1,0 +1,31 @@
+"""
+Full profile
+Full profile to test all generation functionality
+"""
+name = "scope/name"
+version = "1.0.0"
+
+"""
+UseCase
+UseCase description
+"""
+usecase UseCase {
+  input {
+  }
+
+  result {
+    """
+	  Result Field title
+    Result Field description
+    """
+    field! string!
+    
+    namedField
+  }
+}
+
+"""
+Named Field title
+Named Field description
+"""
+field namedField string!

--- a/src/fixtures/profile_with_empty_input_structure.supr
+++ b/src/fixtures/profile_with_empty_input_structure.supr
@@ -1,31 +1,9 @@
-"""
-Full profile
-Full profile to test all generation functionality
-"""
 name = "scope/name"
 version = "1.0.0"
 
-"""
-UseCase
-UseCase description
-"""
 usecase UseCase {
   input {
   }
 
-  result {
-    """
-	  Result Field title
-    Result Field description
-    """
-    field! string!
-    
-    namedField
-  }
+  result string
 }
-
-"""
-Named Field title
-Named Field description
-"""
-field namedField string!

--- a/src/schema.types.spec.ts
+++ b/src/schema.types.spec.ts
@@ -169,6 +169,27 @@ describe('schema.types', () => {
         expect(config).toMatchSnapshot();
       });
     });
+
+    describe('for profile fixture with empty input fields', () => {
+      it('creates arguments without input', async () => {
+        const profileAst = await parseProfileFixture(
+          'profile_with_empty_input_structure',
+        );
+        const profileOutput = await getProfileOutput(
+          'profile_with_empty_input_structure',
+          profileAst,
+        );
+        const config = generateUseCaseFieldConfig(
+          'ScopeName',
+          profileAst,
+          profileSettings,
+          profileOutput.usecases[0],
+          providers,
+        );
+
+        expect(config).toMatchSnapshot();
+      });
+    });
   });
 
   describe('generateProfileConfig', () => {

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -132,9 +132,10 @@ export function generateUseCaseFieldConfig(
     useCase.result,
   );
 
-  const InputType = useCase.input
-    ? generateStructureInputType(`${useCasePrefix}Input`, useCase.input)
-    : undefined;
+  const InputType =
+    useCase.input && Object.keys(useCase.input.fields).length !== 0
+      ? generateStructureInputType(`${useCasePrefix}Input`, useCase.input)
+      : undefined;
 
   const OptionsType = generateUseCaseOptionsInputType(
     `${useCasePrefix}Options`,


### PR DESCRIPTION
This PR fixes generating schema for Comlink profiles with empty use case input fields.

Generated GraphQL schema must define one or more input fields.