### PR TITLE
Handle usecase without result as result being nullable boolean

### DIFF
--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -99,13 +99,16 @@ type ScopeProfileTwo {
 }"
 `;
 
-exports[`schema.types generateStructureResultType creates ScopeNameResult as nullable string 1`] = `
+exports[`schema.types generateStructureResultType creates ScopeNameResult as None value 1`] = `
 """"
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameResult {
-  result: String
-}"
+  result: None
+}
+
+"""Represents NULL value"""
+scalar None"
 `;
 
 exports[`schema.types generateStructureResultType creates ScopeNameResult with description and result field 1`] = `

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -99,6 +99,15 @@ type ScopeProfileTwo {
 }"
 `;
 
+exports[`schema.types generateStructureResultType creates ScopeNameResult as nullable string 1`] = `
+""""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameResult {
+  result: String
+}"
+`;
+
 exports[`schema.types generateStructureResultType creates ScopeNameResult with description and result field 1`] = `
 """"
 Wrapping type to handle many possible types returned as result by OneSDK
@@ -122,7 +131,20 @@ type ScopeNameResultNode {
 }"
 `;
 
-exports[`schema.types generateUseCaseFieldConfig for profile fixture creates field config with arguments, resolver and description 1`] = `
+exports[`schema.types generateUseCaseFieldConfig usecase with empty input creates arguments without input 1`] = `
+{
+  "args": {
+    "provider": {
+      "type": "ScopeNameProviderOption",
+    },
+  },
+  "description": undefined,
+  "resolve": [Function],
+  "type": "ScopeNameUseCaseResult",
+}
+`;
+
+exports[`schema.types generateUseCaseFieldConfig valid profile creates field config with arguments, resolver and description 1`] = `
 {
   "args": {
     "input": {
@@ -135,19 +157,6 @@ exports[`schema.types generateUseCaseFieldConfig for profile fixture creates fie
   },
   "description": "UseCase
 UseCase description",
-  "resolve": [Function],
-  "type": "ScopeNameUseCaseResult",
-}
-`;
-
-exports[`schema.types generateUseCaseFieldConfig for profile fixture with empty input fields creates arguments without input 1`] = `
-{
-  "args": {
-    "provider": {
-      "type": "ScopeNameProviderOption",
-    },
-  },
-  "description": undefined,
   "resolve": [Function],
   "type": "ScopeNameUseCaseResult",
 }

--- a/src/schema.types.spec.ts
+++ b/src/schema.types.spec.ts
@@ -250,7 +250,7 @@ describe('schema.types', () => {
       );
     });
 
-    it('creates ScopeNameResult as nullable string', async () => {
+    it('creates ScopeNameResult as None value', async () => {
       const profileOutput = await getProfileOutput('no_result');
       expectSchema(
         generateStructureResultType(

--- a/src/schema.types.spec.ts
+++ b/src/schema.types.spec.ts
@@ -188,22 +188,7 @@ describe('schema.types', () => {
   });
 
   describe('generateUseCaseFieldConfig', () => {
-    it('throws if usecase is missing result', async () => {
-      const profileAst = await parseProfileFixture('no_result');
-      const profileOutput = await getProfileOutput('no_result', profileAst);
-
-      expect(() =>
-        generateUseCaseFieldConfig(
-          'ScopeName',
-          profileAst,
-          profileSettings,
-          profileOutput.usecases[0],
-          providersJsons,
-        ),
-      ).toThrowError();
-    });
-
-    describe('for profile fixture', () => {
+    describe('valid profile', () => {
       it('creates field config with arguments, resolver and description', async () => {
         const profileAst = await parseProfileFixture('profile');
         const profileOutput = await getProfileOutput('profile', profileAst);
@@ -219,7 +204,7 @@ describe('schema.types', () => {
       });
     });
 
-    describe('for profile fixture with empty input fields', () => {
+    describe('usecase with empty input', () => {
       it('creates arguments without input', async () => {
         const profileAst = await parseProfileFixture(
           'profile_with_empty_input_structure',
@@ -257,6 +242,16 @@ describe('schema.types', () => {
   describe('generateStructureResultType', () => {
     it('creates ScopeNameResult with description and result field', async () => {
       const profileOutput = await getProfileOutput('profile');
+      expectSchema(
+        generateStructureResultType(
+          'ScopeNameResult',
+          profileOutput.usecases[0].result as StructureType,
+        ),
+      );
+    });
+
+    it('creates ScopeNameResult as nullable string', async () => {
+      const profileOutput = await getProfileOutput('no_result');
       expectSchema(
         generateStructureResultType(
           'ScopeNameResult',

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -120,10 +120,6 @@ export function generateUseCaseFieldConfig(
   useCase: UseCaseStructure,
   providersJsons: ProvidersJsonRecord,
 ): GraphQLFieldConfig<any, any> {
-  if (!useCase.result) {
-    throw new Error(`${useCase.useCaseName} doesn't have defined result`);
-  }
-
   const useCasePrefix = `${profilePrefix}${pascalize(
     sanitize(useCase.useCaseName),
   )}`;
@@ -134,7 +130,8 @@ export function generateUseCaseFieldConfig(
   );
 
   const InputType =
-    useCase.input && Object.keys(useCase.input.fields).length !== 0
+    useCase.input !== undefined &&
+    Object.keys(useCase.input.fields).length !== 0
       ? generateStructureInputType(`${useCasePrefix}Input`, useCase.input)
       : undefined;
 
@@ -191,11 +188,16 @@ export function generateProfileConfig(
 
 export function generateStructureResultType(
   name: string,
-  structure: StructureType,
+  structure: StructureType | undefined,
 ): GraphQLOutputType {
   debug(`generateStructureResultType for ${name} from structure`, structure);
 
-  const type = outputType(`${name}Node`, structure);
+  let type: GraphQLOutputType;
+  if (structure === undefined) {
+    type = GraphQLString;
+  } else {
+    type = outputType(`${name}Node`, structure);
+  }
 
   return new GraphQLObjectType({
     name,

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -194,7 +194,7 @@ export function generateStructureResultType(
 
   let type: GraphQLOutputType;
   if (structure === undefined) {
-    type = GraphQLString;
+    type = GraphQLNone;
   } else {
     type = outputType(`${name}Node`, structure);
   }
@@ -602,3 +602,21 @@ export function inputType(
       throw new Error(`Variable type not implemented for: ${structure.kind}`);
   }
 }
+
+export const GraphQLNone = new GraphQLScalarType({
+  name: 'None',
+
+  description: 'Represents NULL value',
+
+  serialize() {
+    return null;
+  },
+
+  parseValue() {
+    return null;
+  },
+
+  parseLiteral() {
+    return null;
+  },
+});


### PR DESCRIPTION
Fixed #44 

Lets have following profile

```
name = "scope/name"
version = "1.0.0"
usecase UseCase safe {
  input {
    field string
  }
}
```

Possible solution is to defined own `None` type representing null.

```gql
query MyQuery {
  ScopeName {
    UseCase(input: {field: "f"}) {
      result
    }
  }
}
```
