### PR TITLE
Add loading from registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.3] - 2023-03-24
 ### Fixed
-- generate schema when use case contains empty input fields without input argument
-- Configurable parameters are now taken from provider definition instead of super.json's providers section - [#41](https://github.com/superfaceai/one-service/pull/41)
+- Handle use-cases without result defined - [#43](https://github.com/superfaceai/one-service/pull/43)
+- Configurable parameters are now taken from provider definition instead of super.json's providers section - [#41](https://github.com/superfaceai/one-service/pull/41), [#45](https://github.com/superfaceai/one-service/pull/45)
 
 ### Added
 - **BREAKING** Added UseCase arguemnt `provider` to allow provider specific configuration and avoid collisions between them [#41](https://github.com/superfaceai/one-service/pull/41)
 
+## [2.2.3] - 2023-03-24
+### Fixed
+- generate schema when use case contains empty input fields without input argument - [#42](https://github.com/superfaceai/one-service/pull/42)
+
 ## [2.2.2] - 2023-03-09
 ### Fixed
-- generate _superJson introspection schema and resolver with SuperJson document from argument instead of loading it from file system
+- generate _superJson introspection schema and resolver with SuperJson document from argument instead of loading it from file system - [#38](https://github.com/superfaceai/one-service/pull/38)
 
 ## [2.2.1] - 2023-03-07
 ### Fixed

--- a/src/provider.spec.ts
+++ b/src/provider.spec.ts
@@ -1,0 +1,76 @@
+import { NormalizedSuperJsonDocument, ProviderJson } from '@superfaceai/ast';
+import {
+  fetchProviderInfo,
+  resolveProviderJson,
+  unknownProviderInfoError,
+} from '@superfaceai/one-sdk';
+import { load } from './provider';
+
+jest.mock('@superfaceai/one-sdk');
+
+describe('provider', () => {
+  const superJson: NormalizedSuperJsonDocument = {
+    profiles: {
+      'scope/name': {
+        version: '1.0.0',
+        priority: [],
+        defaults: {},
+        providers: { provider: { defaults: {} } },
+      },
+    },
+    providers: {
+      provider: {
+        security: [],
+        parameters: {},
+      },
+    },
+  };
+
+  const providerJson: ProviderJson = {
+    name: 'provider',
+    services: [
+      {
+        id: 'default',
+        baseUrl: 'https://supreface.test',
+      },
+    ],
+    defaultService: 'default',
+  };
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('loads provider from local file', async () => {
+    jest.mocked(resolveProviderJson).mockResolvedValue(providerJson);
+    const result = await load(superJson, 'provider');
+
+    expect(resolveProviderJson).toBeCalled();
+    expect(fetchProviderInfo).not.toBeCalled();
+    expect(result).toEqual(providerJson);
+  });
+
+  it('loads provider from registry', async () => {
+    jest.mocked(resolveProviderJson).mockResolvedValue(undefined);
+    jest.mocked(fetchProviderInfo).mockResolvedValue(providerJson);
+    const result = await load(superJson, 'provider');
+
+    expect(resolveProviderJson).toBeCalled();
+    expect(fetchProviderInfo).toBeCalled();
+    expect(result).toEqual(providerJson);
+  });
+
+  it('throws error if provider not found', async () => {
+    jest.mocked(resolveProviderJson).mockResolvedValue(undefined);
+    jest.mocked(fetchProviderInfo).mockRejectedValue(
+      unknownProviderInfoError({
+        message: 'Test error',
+        provider: 'provider',
+        body: 'dummy',
+        statusCode: 404,
+      }),
+    );
+
+    await expect(load(superJson, 'provider')).rejects.toThrowError();
+  });
+});

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,7 +1,11 @@
 import { NormalizedSuperJsonDocument, ProviderJson } from '@superfaceai/ast';
 import {
   Config,
+  fetchProviderInfo,
+  NodeCrypto,
+  NodeFetch,
   NodeFileSystem,
+  NodeTimers,
   resolveProviderJson,
 } from '@superfaceai/one-sdk';
 
@@ -9,15 +13,33 @@ export async function load(
   superJson: NormalizedSuperJsonDocument,
   providerName: string,
 ): Promise<ProviderJson> {
-  const providerJson = await resolveProviderJson({
+  const config = new Config(NodeFileSystem);
+
+  // Load from local file
+  let providerJson = await resolveProviderJson({
     providerName,
     superJson,
     fileSystem: NodeFileSystem,
-    config: new Config(NodeFileSystem),
+    config,
   });
 
+  // Load from registry
   if (!providerJson) {
-    throw new Error(`Provider ${providerName} couldn't be resolved`); // TODO: custom error
+    try {
+      providerJson = await fetchProviderInfo(
+        providerName,
+        config,
+        new NodeCrypto(),
+        new NodeFetch(new NodeTimers()),
+      );
+    } catch (_e) {
+      // Ignore error
+    }
+  }
+
+  // Throw error if provider not found
+  if (!providerJson) {
+    throw new Error(`Provider '${providerName}' not found`);
   }
 
   return providerJson;


### PR DESCRIPTION
This PR adds loading provider json from registry.

Unlike `resolveProfileAst`, `resolveProviderJson` isn't loading provide.json from registry, because it is relying on bind call response in OneSDK. I didn't notice that when implementing.