### PR TITLE
Fix non unique type for provider option and invalid field names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 yarn-debug.log*
 yarn-error.log*
 
+src/coverage
 dist
 superface
 workdir/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable parameters are now taken from provider definition instead of super.json's providers section - [#41](https://github.com/superfaceai/one-service/pull/41), [#45](https://github.com/superfaceai/one-service/pull/45)
 
 ### Added
-- **BREAKING** Added UseCase arguemnt `provider` to allow provider specific configuration and avoid collisions between them [#41](https://github.com/superfaceai/one-service/pull/41)
+- **BREAKING** Added UseCase arguemnt `provider` to allow provider specific configuration and avoid collisions between them [#41](https://github.com/superfaceai/one-service/pull/41) [#45](https://github.com/superfaceai/one-service/pull/45) [#46](https://github.com/superfaceai/one-service/pull/46)
 
 ## [2.2.3] - 2023-03-24
 ### Fixed

--- a/src/__snapshots__/schema.spec.ts.snap
+++ b/src/__snapshots__/schema.spec.ts.snap
@@ -1,5 +1,104 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`schema generate generates valid schema for profile with mutiple usecases 1`] = `[]`;
+
+exports[`schema generate generates valid schema for profile with mutiple usecases 2`] = `
+""""Superface.ai ❤️"""
+schema {
+  query: Query
+}
+
+"""Profile's safe use-cases"""
+type Query {
+  Profile: ProfileQuery
+  _superJson: SuperJson
+}
+
+type ProfileQuery {
+  UseCaseOne(provider: ProfileProviderOption): ProfileUseCaseOneResult
+  UseCaseTwo(provider: ProfileProviderOption): ProfileUseCaseTwoResult
+}
+
+"""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ProfileUseCaseOneResult {
+  result: String
+}
+
+"""Provider configuration for OneSDK perform"""
+input ProfileProviderOption {
+  """Provider test configuration"""
+  test: ProfileProviderOptionTestConfig
+}
+
+input ProfileProviderOptionTestConfig {
+  active: Boolean
+  parameters: ProfileProviderOptionTestProviderParameters
+  security: ProfileProviderOptionTestProviderSecurity
+}
+
+"""Provider-specific parameters"""
+input ProfileProviderOptionTestProviderParameters {
+  """Parameter accepted by test"""
+  param_no_default: String
+
+  """Parameter accepted by test"""
+  param_default: String
+}
+
+"""Provider-specific security"""
+input ProfileProviderOptionTestProviderSecurity {
+  """Security accepted by test"""
+  api_key: TestApiKeySecurityValues
+
+  """Security accepted by test"""
+  basic: TestBasicSecurityValues
+
+  """Security accepted by test"""
+  bearer_token: TestBearerTokenSecurityValues
+
+  """Security accepted by test"""
+  digest: TestDigestSecurityValues
+}
+
+input TestApiKeySecurityValues {
+  apikey: String
+}
+
+input TestBasicSecurityValues {
+  username: String
+  password: String
+}
+
+input TestBearerTokenSecurityValues {
+  token: String
+}
+
+input TestDigestSecurityValues {
+  username: String
+  password: String
+}
+
+"""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ProfileUseCaseTwoResult {
+  result: String
+}
+
+type SuperJson {
+  profiles: [ProfileInfo]
+  providers: [String]
+}
+
+type ProfileInfo {
+  name: String
+  version: String
+  providers: [String]
+}"
+`;
+
 exports[`schema generate generates valid schema for profile without scope 1`] = `[]`;
 
 exports[`schema generate generates valid schema for profile without scope 2`] = `
@@ -88,6 +187,201 @@ type ProfileInfo {
   name: String
   version: String
   providers: [String]
+}"
+`;
+
+exports[`schema generate generates valid schema for usecase with empty input 1`] = `[]`;
+
+exports[`schema generate generates valid schema for usecase with empty input 2`] = `
+""""Superface.ai ❤️"""
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"""Profile's safe use-cases"""
+type Query {
+  _superJson: SuperJson
+}
+
+type SuperJson {
+  profiles: [ProfileInfo]
+  providers: [String]
+}
+
+type ProfileInfo {
+  name: String
+  version: String
+  providers: [String]
+}
+
+"""Profile's unsafe and idempotent use-cases"""
+type Mutation {
+  ScopeName: ScopeNameMutation
+}
+
+type ScopeNameMutation {
+  UseCase(provider: ScopeNameProviderOption): ScopeNameUseCaseResult
+}
+
+"""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameUseCaseResult {
+  result: String
+}
+
+"""Provider configuration for OneSDK perform"""
+input ScopeNameProviderOption {
+  """Provider test configuration"""
+  test: ScopeNameProviderOptionTestConfig
+}
+
+input ScopeNameProviderOptionTestConfig {
+  active: Boolean
+  parameters: ScopeNameProviderOptionTestProviderParameters
+  security: ScopeNameProviderOptionTestProviderSecurity
+}
+
+"""Provider-specific parameters"""
+input ScopeNameProviderOptionTestProviderParameters {
+  """Parameter accepted by test"""
+  param_no_default: String
+
+  """Parameter accepted by test"""
+  param_default: String
+}
+
+"""Provider-specific security"""
+input ScopeNameProviderOptionTestProviderSecurity {
+  """Security accepted by test"""
+  api_key: TestApiKeySecurityValues
+
+  """Security accepted by test"""
+  basic: TestBasicSecurityValues
+
+  """Security accepted by test"""
+  bearer_token: TestBearerTokenSecurityValues
+
+  """Security accepted by test"""
+  digest: TestDigestSecurityValues
+}
+
+input TestApiKeySecurityValues {
+  apikey: String
+}
+
+input TestBasicSecurityValues {
+  username: String
+  password: String
+}
+
+input TestBearerTokenSecurityValues {
+  token: String
+}
+
+input TestDigestSecurityValues {
+  username: String
+  password: String
+}"
+`;
+
+exports[`schema generate generates valid schema for usecase without result 1`] = `[]`;
+
+exports[`schema generate generates valid schema for usecase without result 2`] = `
+""""Superface.ai ❤️"""
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"""Profile's safe use-cases"""
+type Query {
+  _superJson: SuperJson
+}
+
+type SuperJson {
+  profiles: [ProfileInfo]
+  providers: [String]
+}
+
+type ProfileInfo {
+  name: String
+  version: String
+  providers: [String]
+}
+
+"""Profile's unsafe and idempotent use-cases"""
+type Mutation {
+  ScopeName: ScopeNameMutation
+}
+
+type ScopeNameMutation {
+  NoResult(provider: ScopeNameProviderOption): ScopeNameNoResultResult
+}
+
+"""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameNoResultResult {
+  result: None
+}
+
+"""Represents NULL value"""
+scalar None
+
+"""Provider configuration for OneSDK perform"""
+input ScopeNameProviderOption {
+  """Provider test configuration"""
+  test: ScopeNameProviderOptionTestConfig
+}
+
+input ScopeNameProviderOptionTestConfig {
+  active: Boolean
+  parameters: ScopeNameProviderOptionTestProviderParameters
+  security: ScopeNameProviderOptionTestProviderSecurity
+}
+
+"""Provider-specific parameters"""
+input ScopeNameProviderOptionTestProviderParameters {
+  """Parameter accepted by test"""
+  param_no_default: String
+
+  """Parameter accepted by test"""
+  param_default: String
+}
+
+"""Provider-specific security"""
+input ScopeNameProviderOptionTestProviderSecurity {
+  """Security accepted by test"""
+  api_key: TestApiKeySecurityValues
+
+  """Security accepted by test"""
+  basic: TestBasicSecurityValues
+
+  """Security accepted by test"""
+  bearer_token: TestBearerTokenSecurityValues
+
+  """Security accepted by test"""
+  digest: TestDigestSecurityValues
+}
+
+input TestApiKeySecurityValues {
+  apikey: String
+}
+
+input TestBasicSecurityValues {
+  username: String
+  password: String
+}
+
+input TestBearerTokenSecurityValues {
+  token: String
+}
+
+input TestDigestSecurityValues {
+  username: String
+  password: String
 }"
 `;
 

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -28,6 +28,9 @@ input Test {
 
   """Provider superface configuration"""
   superface: TestSuperfaceConfig
+
+  """Provider gql_bad-name configuration"""
+  gql_bad__name: TestGqlBadNameConfig
 }
 
 input TestMockConfig {
@@ -77,6 +80,10 @@ input SuperfaceBearerTokenSecurityValues {
 input SuperfaceDigestSecurityValues {
   username: String
   password: String
+}
+
+input TestGqlBadNameConfig {
+  active: Boolean
 }"
 `;
 

--- a/src/fixtures/profile_multiple_use_cases.supr
+++ b/src/fixtures/profile_multiple_use_cases.supr
@@ -1,0 +1,10 @@
+name = "profile"
+version = "1.0.0"
+
+usecase UseCaseOne safe {
+  result string
+}
+
+usecase UseCaseTwo safe {
+  result string
+}

--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -11,13 +11,34 @@ describe('schema', () => {
       const schema = await generate(
         await createSuperJson('profile_without_scope'),
       );
-
       expectSchemaValidationErrors(schema);
       expectSchema(schema);
     });
 
     it('generates valid schema for usecases mapped to mutation only', async () => {
       const schema = await generate(await createSuperJson('unsafe_only'));
+      expectSchemaValidationErrors(schema);
+      expectSchema(schema);
+    });
+
+    it('generates valid schema for profile with mutiple usecases', async () => {
+      const schema = await generate(
+        await createSuperJson('profile_multiple_use_cases'),
+      );
+      expectSchemaValidationErrors(schema);
+      expectSchema(schema);
+    });
+
+    it('generates valid schema for usecase with empty input', async () => {
+      const schema = await generate(
+        await createSuperJson('profile_with_empty_input_structure'),
+      );
+      expectSchemaValidationErrors(schema);
+      expectSchema(schema);
+    });
+
+    it('generates valid schema for usecase without result', async () => {
+      const schema = await generate(await createSuperJson('no_result'));
       expectSchemaValidationErrors(schema);
       expectSchema(schema);
     });

--- a/src/schema.types.spec.ts
+++ b/src/schema.types.spec.ts
@@ -106,6 +106,9 @@ describe('schema.types', () => {
       superface: {
         defaults: {},
       },
+      'gql_bad-name': {
+        defaults: {},
+      },
     },
   };
 
@@ -159,6 +162,16 @@ describe('schema.types', () => {
       parameters: [
         {
           name: 'accessToken',
+        },
+      ],
+    },
+    'gql_bad-name': {
+      name: 'gql_bad-name',
+      defaultService: 'default',
+      services: [
+        {
+          id: 'default',
+          baseUrl: 'https://superface.test',
         },
       ],
     },

--- a/src/schema.types.spec.ts
+++ b/src/schema.types.spec.ts
@@ -10,7 +10,12 @@ import {
   PrimitiveStructure,
   StructureType,
 } from '@superfaceai/parser';
-import { GraphQLObjectType, GraphQLString } from 'graphql';
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql';
 import {
   enumType,
   generateProfileConfig,
@@ -188,16 +193,30 @@ describe('schema.types', () => {
   });
 
   describe('generateUseCaseFieldConfig', () => {
+    const ProfileProviderOptionType = new GraphQLInputObjectType({
+      name: 'ScopeNameProviderOption',
+      fields: {
+        provider: {
+          type: new GraphQLInputObjectType({
+            name: 'ScopeNameProviderConfig',
+            fields: {
+              active: { type: GraphQLBoolean },
+            },
+          }),
+        },
+      },
+    });
+
     describe('valid profile', () => {
       it('creates field config with arguments, resolver and description', async () => {
         const profileAst = await parseProfileFixture('profile');
         const profileOutput = await getProfileOutput('profile', profileAst);
+
         const config = generateUseCaseFieldConfig(
           'ScopeName',
           profileAst,
-          profileSettings,
           profileOutput.usecases[0],
-          providersJsons,
+          ProfileProviderOptionType,
         );
 
         expect(config).toMatchSnapshot();
@@ -216,9 +235,8 @@ describe('schema.types', () => {
         const config = generateUseCaseFieldConfig(
           'ScopeName',
           profileAst,
-          profileSettings,
           profileOutput.usecases[0],
-          providersJsons,
+          ProfileProviderOptionType,
         );
 
         expect(config).toMatchSnapshot();

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -42,6 +42,7 @@ import {
   pascalize,
   sanitize,
   sanitizeForGQLTypeName,
+  sanitizeProviderName,
   typeFromSafety,
 } from './schema.utils';
 import { ArrayMultiMap } from './structures';
@@ -268,8 +269,7 @@ export function generateProfileProviderOptionInputType(
       }),
     };
 
-    // TODO: sanitize provider name
-    providerFields[providerName] = {
+    providerFields[sanitizeProviderName(providerName)] = {
       description: `Provider ${providerName} configuration`,
       type: new GraphQLInputObjectType({
         name: `${namePrefix}Config`,

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -268,6 +268,7 @@ export function generateProfileProviderOptionInputType(
       }),
     };
 
+    // TODO: sanitize provider name
     providerFields[providerName] = {
       description: `Provider ${providerName} configuration`,
       type: new GraphQLInputObjectType({

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -70,6 +70,12 @@ export async function generateProfileTypes(
   const queryFields: GraphQLFieldConfigMap<any, any> = {}; // TODO: something better than any?
   const mutationFields: GraphQLFieldConfigMap<any, any> = {}; // TODO: something better than any?
 
+  const ProfileProviderOptionType = generateProfileProviderOptionInputType(
+    `${profilePrefix}ProviderOption`,
+    profileSettings,
+    providersJsons,
+  );
+
   for (const useCase of output.usecases) {
     const useCaseInfo = useCasesInfo.find(
       (uc) => uc.name === useCase.useCaseName,
@@ -82,9 +88,8 @@ export async function generateProfileTypes(
     const useCaseFieldConfig = generateUseCaseFieldConfig(
       profilePrefix,
       profileAst,
-      profileSettings,
       useCase,
-      providersJsons,
+      ProfileProviderOptionType,
     );
 
     const type = typeFromSafety(useCaseInfo.safety);
@@ -116,9 +121,8 @@ export async function generateProfileTypes(
 export function generateUseCaseFieldConfig(
   profilePrefix: string,
   profileAst: ProfileDocumentNode,
-  profileSettings: NormalizedProfileSettings,
   useCase: UseCaseStructure,
-  providersJsons: ProvidersJsonRecord,
+  ProfileProviderOptionType?: GraphQLInputObjectType,
 ): GraphQLFieldConfig<any, any> {
   const useCasePrefix = `${profilePrefix}${pascalize(
     sanitize(useCase.useCaseName),
@@ -135,17 +139,13 @@ export function generateUseCaseFieldConfig(
       ? generateStructureInputType(`${useCasePrefix}Input`, useCase.input)
       : undefined;
 
-  const ProfileProviderOptionType = generateProfileProviderOptionInputType(
-    `${profilePrefix}ProviderOption`,
-    profileSettings,
-    providersJsons,
-  );
+  const args: GraphQLFieldConfigArgumentMap = {};
 
-  const args: GraphQLFieldConfigArgumentMap = {
-    provider: {
+  if (ProfileProviderOptionType) {
+    args.provider = {
       type: ProfileProviderOptionType,
-    },
-  };
+    };
+  }
 
   if (InputType) {
     args.input = {

--- a/src/schema.utils.spec.ts
+++ b/src/schema.utils.spec.ts
@@ -2,11 +2,13 @@ import { GraphQLString } from 'graphql';
 import {
   camelize,
   capitalize,
+  desanitizeProviderName,
   description,
   hasFieldsDefined,
   pascalize,
   sanitize,
   sanitizedProfileName,
+  sanitizeProviderName,
   typeFromSafety,
 } from './schema.utils';
 
@@ -78,6 +80,15 @@ describe('schema.utils', () => {
           kind: 'ProfileDocument',
         }),
       ).toBe('ScopeNameProfileName');
+    });
+  });
+
+  describe('sanitizeProviderName + desanitizeProviderName', () => {
+    it('returns original provider name', () => {
+      const provider = 'foo-bar_baz';
+      expect(desanitizeProviderName(sanitizeProviderName(provider))).toBe(
+        provider,
+      );
     });
   });
 

--- a/src/schema.utils.ts
+++ b/src/schema.utils.ts
@@ -26,6 +26,10 @@ export function camelize(input: string): string {
   });
 }
 
+export function snake_cased(input: string): string {
+  return input.replace(/([A-Z])/g, '_$1').toLowerCase();
+}
+
 export function pascalize(input: string): string {
   return capitalize(camelize(input));
 }
@@ -43,6 +47,23 @@ export function sanitizedProfileName(profileAst: ProfileDocumentNode): string {
       }).toString(),
     ),
   );
+}
+
+/**
+ * @param provider Provider name with characters: [a-z][a-z0-9_-]
+ * @returns GQL valid field name representing provider name with characters: [_a-zA-Z][_a-zA-Z0-9]
+ *
+ * Sanitization can be reversed by desanitizeProviderName
+ */
+export function sanitizeProviderName(provider: string): string {
+  return provider.replace(/-/g, '__');
+}
+
+/**
+ * Inversed sanitizeProviderName
+ */
+export function desanitizeProviderName(provider: string): string {
+  return provider.replace(/__/g, '-');
 }
 
 export function hasFieldsDefined(

--- a/src/schema.utils.ts
+++ b/src/schema.utils.ts
@@ -13,7 +13,7 @@ import { GraphQLFieldConfigMap, GraphQLInputFieldConfigMap } from 'graphql';
  * Comlink allowed: [a-z][a-z0-9_-] + scope delimiter /
  */
 export function sanitize(input: string): string {
-  return input.replace(/\//g, '_').replace(/-/g, '_');
+  return input.replace(/[-_/]/g, '_');
 }
 
 export function capitalize(input: string): string {
@@ -28,6 +28,10 @@ export function camelize(input: string): string {
 
 export function pascalize(input: string): string {
   return capitalize(camelize(input));
+}
+
+export function sanitizeForGQLTypeName(input: string): string {
+  return pascalize(sanitize(input));
 }
 
 export function sanitizedProfileName(profileAst: ProfileDocumentNode): string {


### PR DESCRIPTION
This PR fixes three issues:

1. Provider option type wasn't unique. It got defined for every use-case with the same name. The solution was to move it up to profile level and pass to a function creating use-case schema – fixed in this [commit](https://github.com/superfaceai/one-service/commit/a4606f4f26193456b851292502ee5f8d4a618160)
2. Comlink provider name is valid if contains only the following characters`[a-z][a-z0-9_-]` on the other side GQL allows `[_a-zA-Z][_a-zA-Z0-9]` so there is a problem with `-` char. So we need to sanitize it, but in a way it is reversible for mapping to the provider name specified in `super.json`. @jnv proposed replacing `-` with a capitalized letter, unfortunately in corner case `-` can be the last char in the name e.g. `provider-` (I know this should be fixed too). So, I decided to fix it with a double dash, replacing `-` with `__`. If provider name will contain `__` it will be broken and unable to use with OneService.
3. Bug in creating GQL type names. [commit](https://github.com/superfaceai/one-service/commit/192bcfe06c4fe5f885e408276ca548f2be34114c)


<img width="1450" alt="image" src="https://user-images.githubusercontent.com/959390/228272300-d6b94a21-25ec-45d5-8039-bc426b4e5cb8.png">

<img width="1483" alt="image" src="https://user-images.githubusercontent.com/959390/228274905-79cf367e-cd62-4992-a201-985532927446.png">

