### PR TITLE
Provider config GQL type name collision fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix Provider Configuration GraphQL type name collision
 
 ## [3.0.0] - 2023-03-30
 ### Added

--- a/src/__snapshots__/schema.spec.ts.snap
+++ b/src/__snapshots__/schema.spec.ts.snap
@@ -15,8 +15,8 @@ type Query {
 }
 
 type ProfileQuery {
-  UseCaseOne(provider: ProfileProviderOption): ProfileUseCaseOneResult
-  UseCaseTwo(provider: ProfileProviderOption): ProfileUseCaseTwoResult
+  UseCaseOne(provider: ProfileProviderInput): ProfileUseCaseOneResult
+  UseCaseTwo(provider: ProfileProviderInput): ProfileUseCaseTwoResult
 }
 
 """
@@ -27,19 +27,19 @@ type ProfileUseCaseOneResult {
 }
 
 """Provider configuration for OneSDK perform"""
-input ProfileProviderOption {
+input ProfileProviderInput {
   """Provider test configuration"""
-  test: ProfileProviderOptionTestConfig
+  test: TestProviderConfig
 }
 
-input ProfileProviderOptionTestConfig {
+input TestProviderConfig {
   active: Boolean
-  parameters: ProfileProviderOptionTestProviderParameters
-  security: ProfileProviderOptionTestProviderSecurity
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
 }
 
 """Provider-specific parameters"""
-input ProfileProviderOptionTestProviderParameters {
+input TestProviderParameters {
   """Parameter accepted by test"""
   param_no_default: String
 
@@ -48,7 +48,7 @@ input ProfileProviderOptionTestProviderParameters {
 }
 
 """Provider-specific security"""
-input ProfileProviderOptionTestProviderSecurity {
+input TestProviderSecurity {
   """Security accepted by test"""
   api_key: TestApiKeySecurityValues
 
@@ -114,7 +114,7 @@ type Query {
 }
 
 type ProfileQuery {
-  UseCase(provider: ProfileProviderOption): ProfileUseCaseResult
+  UseCase(provider: ProfileProviderInput): ProfileUseCaseResult
 }
 
 """
@@ -125,19 +125,19 @@ type ProfileUseCaseResult {
 }
 
 """Provider configuration for OneSDK perform"""
-input ProfileProviderOption {
+input ProfileProviderInput {
   """Provider test configuration"""
-  test: ProfileProviderOptionTestConfig
+  test: TestProviderConfig
 }
 
-input ProfileProviderOptionTestConfig {
+input TestProviderConfig {
   active: Boolean
-  parameters: ProfileProviderOptionTestProviderParameters
-  security: ProfileProviderOptionTestProviderSecurity
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
 }
 
 """Provider-specific parameters"""
-input ProfileProviderOptionTestProviderParameters {
+input TestProviderParameters {
   """Parameter accepted by test"""
   param_no_default: String
 
@@ -146,7 +146,7 @@ input ProfileProviderOptionTestProviderParameters {
 }
 
 """Provider-specific security"""
-input ProfileProviderOptionTestProviderSecurity {
+input TestProviderSecurity {
   """Security accepted by test"""
   api_key: TestApiKeySecurityValues
 
@@ -190,6 +190,102 @@ type ProfileInfo {
 }"
 `;
 
+exports[`schema generate generates valid schema for two profiles with same provider 1`] = `[]`;
+
+exports[`schema generate generates valid schema for two profiles with same provider 2`] = `
+""""Superface.ai ❤️"""
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"""Profile's safe use-cases"""
+type Query {
+  _superJson: SuperJson
+}
+
+type SuperJson {
+  profiles: [ProfileInfo]
+  providers: [String]
+}
+
+type ProfileInfo {
+  name: String
+  version: String
+  providers: [String]
+}
+
+"""Profile's unsafe and idempotent use-cases"""
+type Mutation {
+  ScopeName: ScopeNameMutation
+}
+
+type ScopeNameMutation {
+  UnsafeUsecase(provider: ScopeNameProviderInput): ScopeNameUnsafeUsecaseResult
+}
+
+"""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameUnsafeUsecaseResult {
+  result: Int
+}
+
+"""Provider configuration for OneSDK perform"""
+input ScopeNameProviderInput {
+  """Provider test configuration"""
+  test: TestProviderConfig
+}
+
+input TestProviderConfig {
+  active: Boolean
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
+}
+
+"""Provider-specific parameters"""
+input TestProviderParameters {
+  """Parameter accepted by test"""
+  param_no_default: String
+
+  """Parameter accepted by test"""
+  param_default: String
+}
+
+"""Provider-specific security"""
+input TestProviderSecurity {
+  """Security accepted by test"""
+  api_key: TestApiKeySecurityValues
+
+  """Security accepted by test"""
+  basic: TestBasicSecurityValues
+
+  """Security accepted by test"""
+  bearer_token: TestBearerTokenSecurityValues
+
+  """Security accepted by test"""
+  digest: TestDigestSecurityValues
+}
+
+input TestApiKeySecurityValues {
+  apikey: String
+}
+
+input TestBasicSecurityValues {
+  username: String
+  password: String
+}
+
+input TestBearerTokenSecurityValues {
+  token: String
+}
+
+input TestDigestSecurityValues {
+  username: String
+  password: String
+}"
+`;
+
 exports[`schema generate generates valid schema for usecase with empty input 1`] = `[]`;
 
 exports[`schema generate generates valid schema for usecase with empty input 2`] = `
@@ -221,7 +317,7 @@ type Mutation {
 }
 
 type ScopeNameMutation {
-  UseCase(provider: ScopeNameProviderOption): ScopeNameUseCaseResult
+  UseCase(provider: ScopeNameProviderInput): ScopeNameUseCaseResult
 }
 
 """
@@ -232,19 +328,19 @@ type ScopeNameUseCaseResult {
 }
 
 """Provider configuration for OneSDK perform"""
-input ScopeNameProviderOption {
+input ScopeNameProviderInput {
   """Provider test configuration"""
-  test: ScopeNameProviderOptionTestConfig
+  test: TestProviderConfig
 }
 
-input ScopeNameProviderOptionTestConfig {
+input TestProviderConfig {
   active: Boolean
-  parameters: ScopeNameProviderOptionTestProviderParameters
-  security: ScopeNameProviderOptionTestProviderSecurity
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
 }
 
 """Provider-specific parameters"""
-input ScopeNameProviderOptionTestProviderParameters {
+input TestProviderParameters {
   """Parameter accepted by test"""
   param_no_default: String
 
@@ -253,7 +349,7 @@ input ScopeNameProviderOptionTestProviderParameters {
 }
 
 """Provider-specific security"""
-input ScopeNameProviderOptionTestProviderSecurity {
+input TestProviderSecurity {
   """Security accepted by test"""
   api_key: TestApiKeySecurityValues
 
@@ -317,7 +413,7 @@ type Mutation {
 }
 
 type ScopeNameMutation {
-  NoResult(provider: ScopeNameProviderOption): ScopeNameNoResultResult
+  NoResult(provider: ScopeNameProviderInput): ScopeNameNoResultResult
 }
 
 """
@@ -331,19 +427,19 @@ type ScopeNameNoResultResult {
 scalar None
 
 """Provider configuration for OneSDK perform"""
-input ScopeNameProviderOption {
+input ScopeNameProviderInput {
   """Provider test configuration"""
-  test: ScopeNameProviderOptionTestConfig
+  test: TestProviderConfig
 }
 
-input ScopeNameProviderOptionTestConfig {
+input TestProviderConfig {
   active: Boolean
-  parameters: ScopeNameProviderOptionTestProviderParameters
-  security: ScopeNameProviderOptionTestProviderSecurity
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
 }
 
 """Provider-specific parameters"""
-input ScopeNameProviderOptionTestProviderParameters {
+input TestProviderParameters {
   """Parameter accepted by test"""
   param_no_default: String
 
@@ -352,7 +448,7 @@ input ScopeNameProviderOptionTestProviderParameters {
 }
 
 """Provider-specific security"""
-input ScopeNameProviderOptionTestProviderSecurity {
+input TestProviderSecurity {
   """Security accepted by test"""
   api_key: TestApiKeySecurityValues
 
@@ -416,7 +512,7 @@ type Mutation {
 }
 
 type ScopeNameMutation {
-  UnsafeUsecase(provider: ScopeNameProviderOption): ScopeNameUnsafeUsecaseResult
+  UnsafeUsecase(provider: ScopeNameProviderInput): ScopeNameUnsafeUsecaseResult
 }
 
 """
@@ -427,19 +523,19 @@ type ScopeNameUnsafeUsecaseResult {
 }
 
 """Provider configuration for OneSDK perform"""
-input ScopeNameProviderOption {
+input ScopeNameProviderInput {
   """Provider test configuration"""
-  test: ScopeNameProviderOptionTestConfig
+  test: TestProviderConfig
 }
 
-input ScopeNameProviderOptionTestConfig {
+input TestProviderConfig {
   active: Boolean
-  parameters: ScopeNameProviderOptionTestProviderParameters
-  security: ScopeNameProviderOptionTestProviderSecurity
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
 }
 
 """Provider-specific parameters"""
-input ScopeNameProviderOptionTestProviderParameters {
+input TestProviderParameters {
   """Parameter accepted by test"""
   param_no_default: String
 
@@ -448,7 +544,7 @@ input ScopeNameProviderOptionTestProviderParameters {
 }
 
 """Provider-specific security"""
-input ScopeNameProviderOptionTestProviderSecurity {
+input TestProviderSecurity {
   """Security accepted by test"""
   api_key: TestApiKeySecurityValues
 

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -22,35 +22,35 @@ Full profile to test all generation functionality",
 
 exports[`schema.types generateProfileProviderOptionInputType creates provider object with security and parameters field 1`] = `
 """"Provider configuration for OneSDK perform"""
-input Test {
+input TestProviderInput {
   """Provider mock configuration"""
-  mock: TestMockConfig
+  mock: MockProviderConfig
 
   """Provider superface configuration"""
-  superface: TestSuperfaceConfig
+  superface: SuperfaceProviderConfig
 
   """Provider gql_bad-name configuration"""
-  gql_bad__name: TestGqlBadNameConfig
+  gql_bad__name: GqlBadNameProviderConfig
 }
 
-input TestMockConfig {
+input MockProviderConfig {
   active: Boolean
 }
 
-input TestSuperfaceConfig {
+input SuperfaceProviderConfig {
   active: Boolean
-  parameters: TestSuperfaceProviderParameters
-  security: TestSuperfaceProviderSecurity
+  parameters: SuperfaceProviderParameters
+  security: SuperfaceProviderSecurity
 }
 
 """Provider-specific parameters"""
-input TestSuperfaceProviderParameters {
+input SuperfaceProviderParameters {
   """Parameter accepted by superface"""
   accessToken: String
 }
 
 """Provider-specific security"""
-input TestSuperfaceProviderSecurity {
+input SuperfaceProviderSecurity {
   """Security accepted by superface"""
   api_key: SuperfaceApiKeySecurityValues
 
@@ -82,7 +82,7 @@ input SuperfaceDigestSecurityValues {
   password: String
 }
 
-input TestGqlBadNameConfig {
+input GqlBadNameProviderConfig {
   active: Boolean
 }"
 `;
@@ -304,6 +304,23 @@ enum MyObjectTypeEnum {
   ONE
   TWO
 }"
+`;
+
+exports[`schema.types prepareProviderConfigTypeMap creates map of provider config types 1`] = `
+{
+  "gql_bad-name": {
+    "description": "Provider gql_bad-name configuration",
+    "type": "GqlBadNameProviderConfig",
+  },
+  "mock": {
+    "description": "Provider mock configuration",
+    "type": "MockProviderConfig",
+  },
+  "superface": {
+    "description": "Provider superface configuration",
+    "type": "SuperfaceProviderConfig",
+  },
+}
 `;
 
 exports[`schema.types scalarType returns GraphQLScalarType 1`] = `

--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -9,21 +9,21 @@ describe('schema', () => {
   describe('generate', () => {
     it('generates valid schema for profile without scope', async () => {
       const schema = await generate(
-        await createSuperJson('profile_without_scope'),
+        await createSuperJson(['profile_without_scope']),
       );
       expectSchemaValidationErrors(schema);
       expectSchema(schema);
     });
 
     it('generates valid schema for usecases mapped to mutation only', async () => {
-      const schema = await generate(await createSuperJson('unsafe_only'));
+      const schema = await generate(await createSuperJson(['unsafe_only']));
       expectSchemaValidationErrors(schema);
       expectSchema(schema);
     });
 
     it('generates valid schema for profile with mutiple usecases', async () => {
       const schema = await generate(
-        await createSuperJson('profile_multiple_use_cases'),
+        await createSuperJson(['profile_multiple_use_cases']),
       );
       expectSchemaValidationErrors(schema);
       expectSchema(schema);
@@ -31,14 +31,22 @@ describe('schema', () => {
 
     it('generates valid schema for usecase with empty input', async () => {
       const schema = await generate(
-        await createSuperJson('profile_with_empty_input_structure'),
+        await createSuperJson(['profile_with_empty_input_structure']),
       );
       expectSchemaValidationErrors(schema);
       expectSchema(schema);
     });
 
     it('generates valid schema for usecase without result', async () => {
-      const schema = await generate(await createSuperJson('no_result'));
+      const schema = await generate(await createSuperJson(['no_result']));
+      expectSchemaValidationErrors(schema);
+      expectSchema(schema);
+    });
+
+    it('generates valid schema for two profiles with same provider', async () => {
+      const schema = await generate(
+        await createSuperJson(['safe_only', 'unsafe_only']),
+      );
       expectSchemaValidationErrors(schema);
       expectSchema(schema);
     });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -24,6 +24,7 @@ import { load as loadProvider } from './provider';
 import {
   generateProfileConfig,
   generateProfileTypes,
+  prepareProviderConfigTypeMap,
   ProvidersJsonRecord,
 } from './schema.types';
 import { hasFieldsDefined, sanitizedProfileName } from './schema.utils';
@@ -71,6 +72,8 @@ export async function generate(
     }),
   );
 
+  const providerConfigTypeMap = prepareProviderConfigTypeMap(loadedProviders);
+
   for (const [profile, profileSettings] of Object.entries(superJson.profiles)) {
     debug(`generate start for ${profile}`);
 
@@ -82,7 +85,7 @@ export async function generate(
       profilePrefix,
       loadedProfile.ast,
       profileSettings,
-      loadedProviders,
+      providerConfigTypeMap,
     );
 
     if (QueryType) {

--- a/src/schema.types.spec.ts
+++ b/src/schema.types.spec.ts
@@ -30,6 +30,7 @@ import {
   primitiveType,
   ProvidersJsonRecord,
   scalarType,
+  prepareProviderConfigTypeMap,
 } from './schema.types';
 import {
   expectSchema,
@@ -177,6 +178,8 @@ describe('schema.types', () => {
     },
   };
 
+  const providerConfigTypeMap = prepareProviderConfigTypeMap(providersJsons);
+
   describe('generateProfileTypes', () => {
     it('skips QueryType if no safe usecase is present', async () => {
       const profileAst = await parseProfileFixture('unsafe_only');
@@ -185,7 +188,7 @@ describe('schema.types', () => {
         'ScopeName',
         profileAst,
         profileSettings,
-        providersJsons,
+        providerConfigTypeMap,
       );
 
       expect(result.QueryType).toBeUndefined();
@@ -198,7 +201,7 @@ describe('schema.types', () => {
         'ScopeName',
         profileAst,
         profileSettings,
-        providersJsons,
+        providerConfigTypeMap,
       );
 
       expect(result.MutationType).toBeUndefined();
@@ -292,13 +295,19 @@ describe('schema.types', () => {
     });
   });
 
+  describe('prepareProviderConfigTypeMap', () => {
+    it('creates map of provider config types', () => {
+      expect(prepareProviderConfigTypeMap(providersJsons)).toMatchSnapshot();
+    });
+  });
+
   describe('generateProfileProviderOptionInputType', () => {
     it('creates provider object with security and parameters field', () => {
       expectSchema(
         generateProfileProviderOptionInputType(
           'Test',
           profileSettings,
-          providersJsons,
+          providerConfigTypeMap,
         ),
       );
     });


### PR DESCRIPTION
For more than one profile using the same provider, provider input type was created multiple times, which caused error `Schema must contain uniquely named types but contains multiple types named`

This PR is fixing it by creating all provider configuration before creating profile types.

Follow up for https://github.com/superfaceai/one-service/pull/46