### PR TITLE
Security and parameters loading from super.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix Provider Configuration GraphQL type name collision
+- Fix Provider Configuration GraphQL type name collision - [#47](https://github.com/superfaceai/one-service/pull/47)
+- Fix loading security and parameters from `super.json` - [#48](https://github.com/superfaceai/one-service/pull/48)
 
 ## [3.0.0] - 2023-03-30
 ### Added

--- a/src/one_sdk.spec.ts
+++ b/src/one_sdk.spec.ts
@@ -217,7 +217,21 @@ describe('one_sdk', () => {
     });
 
     describe('provider configurations', () => {
-      it('sets empty object if parameters are not set', async () => {
+      it('passes parameters to perform function', async () => {
+        await callResolver({
+          provider: {
+            test: {
+              parameters: { foo: 'bar' },
+            },
+          },
+        });
+
+        expect(performMock.mock.calls[0][1]['parameters']).toEqual({
+          foo: 'bar',
+        });
+      });
+
+      it('passses undefined if parameters are not set', async () => {
         await callResolver({
           provider: {
             test: {
@@ -226,10 +240,24 @@ describe('one_sdk', () => {
           },
         });
 
-        expect(performMock.mock.calls[0][1]['parameters']).toEqual({});
+        expect(performMock.mock.calls[0][1]['parameters']).toBe(undefined);
       });
 
-      it('sets empty object if security are not set', async () => {
+      it('passes security values to perform function', async () => {
+        await callResolver({
+          provider: {
+            test: {
+              security: { foo: { apikey: 'apikey' } },
+            },
+          },
+        });
+
+        expect(performMock.mock.calls[0][1]['security']).toEqual({
+          foo: { apikey: 'apikey' },
+        });
+      });
+
+      it('passses undefined if security are not set', async () => {
         await callResolver({
           provider: {
             test: {
@@ -238,7 +266,7 @@ describe('one_sdk', () => {
           },
         });
 
-        expect(performMock.mock.calls[0][1]['security']).toEqual({});
+        expect(performMock.mock.calls[0][1]['security']).toBe(undefined);
       });
     });
 

--- a/src/one_sdk.ts
+++ b/src/one_sdk.ts
@@ -13,7 +13,7 @@ let instance: SuperfaceClient;
 export type PerformParams = {
   profile: string;
   useCase: string;
-  input: Record<string, any>;
+  input?: Record<string, any>;
   provider?: string;
   parameters?: Record<string, string>;
   security?: Record<string, Omit<SecurityValues, 'id'>>;
@@ -148,8 +148,6 @@ export function createResolver<
   ): Promise<ResolverResult<TResult>> {
     debug(`Performing ${profile}/${useCase}`, { source, args, context, info });
 
-    const input = args.input ?? {};
-
     const { provider, providerConfig } = prepareProviderConfig(
       args.provider,
       profile,
@@ -160,10 +158,10 @@ export function createResolver<
       const result = await perform({
         profile,
         useCase,
-        input,
         provider,
-        parameters: providerConfig.parameters ?? {},
-        security: providerConfig.security ?? {},
+        input: args.input ?? {},
+        parameters: providerConfig.parameters,
+        security: providerConfig.security,
         oneSdk: context?.getOneSdkInstance?.(),
       });
 


### PR DESCRIPTION
OneService was passing empty object `{}`, if something is passed, OneSDK uses it and ignores values in `super.json`

https://github.com/superfaceai/one-sdk-js/blob/69d86d18b8b6d2a1b1537da23cbd708c5409e0b9/src/core/profile-provider/profile-provider.ts#L129