### PR TITLE
Sanitize security ids for GQL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix Provider Configuration GraphQL type name collision - [#47](https://github.com/superfaceai/one-service/pull/47)
 - Fix loading security and parameters from `super.json` - [#48](https://github.com/superfaceai/one-service/pull/48)
+- Sanitize security ids for GQL schema and desanitized for OneSDK - [#49](https://github.com/superfaceai/one-service/pull/49)
 
 ## [3.0.0] - 2023-03-30
 ### Added

--- a/src/__snapshots__/schema.spec.ts.snap
+++ b/src/__snapshots__/schema.spec.ts.snap
@@ -50,7 +50,7 @@ input TestProviderParameters {
 """Provider-specific security"""
 input TestProviderSecurity {
   """Security accepted by test"""
-  api_key: TestApiKeySecurityValues
+  api__key: TestApiKeySecurityValues
 
   """Security accepted by test"""
   basic: TestBasicSecurityValues
@@ -148,7 +148,7 @@ input TestProviderParameters {
 """Provider-specific security"""
 input TestProviderSecurity {
   """Security accepted by test"""
-  api_key: TestApiKeySecurityValues
+  api__key: TestApiKeySecurityValues
 
   """Security accepted by test"""
   basic: TestBasicSecurityValues
@@ -255,7 +255,7 @@ input TestProviderParameters {
 """Provider-specific security"""
 input TestProviderSecurity {
   """Security accepted by test"""
-  api_key: TestApiKeySecurityValues
+  api__key: TestApiKeySecurityValues
 
   """Security accepted by test"""
   basic: TestBasicSecurityValues
@@ -351,7 +351,7 @@ input TestProviderParameters {
 """Provider-specific security"""
 input TestProviderSecurity {
   """Security accepted by test"""
-  api_key: TestApiKeySecurityValues
+  api__key: TestApiKeySecurityValues
 
   """Security accepted by test"""
   basic: TestBasicSecurityValues
@@ -450,7 +450,7 @@ input TestProviderParameters {
 """Provider-specific security"""
 input TestProviderSecurity {
   """Security accepted by test"""
-  api_key: TestApiKeySecurityValues
+  api__key: TestApiKeySecurityValues
 
   """Security accepted by test"""
   basic: TestBasicSecurityValues
@@ -546,7 +546,7 @@ input TestProviderParameters {
 """Provider-specific security"""
 input TestProviderSecurity {
   """Security accepted by test"""
-  api_key: TestApiKeySecurityValues
+  api__key: TestApiKeySecurityValues
 
   """Security accepted by test"""
   basic: TestBasicSecurityValues

--- a/src/fixtures/test.provider.json
+++ b/src/fixtures/test.provider.json
@@ -20,7 +20,7 @@
   ],
   "securitySchemes": [
     {
-      "id": "api_key",
+      "id": "api-key",
       "type": "apiKey",
       "in": "header",
       "name": "X-API-KEY"

--- a/src/one_sdk.spec.ts
+++ b/src/one_sdk.spec.ts
@@ -8,6 +8,7 @@ import {
   getInstance,
   perform,
   prepareProviderConfig,
+  prepareSecurity,
   ResolverArgs,
   ResolverContext,
 } from './one_sdk';
@@ -182,6 +183,18 @@ describe('one_sdk', () => {
     });
   });
 
+  describe('prepareSecurity', () => {
+    it('returns undefined security if security is undefined', async () => {
+      expect(prepareSecurity(undefined)).toBe(undefined);
+    });
+
+    it('returns desanitized security ids', async () => {
+      expect(prepareSecurity({ foo__bar: { apikey: 'apikey' } })).toEqual({
+        'foo-bar': { apikey: 'apikey' },
+      });
+    });
+  });
+
   describe('createResolver', () => {
     let resolverResult: any;
 
@@ -267,6 +280,22 @@ describe('one_sdk', () => {
         });
 
         expect(performMock.mock.calls[0][1]['security']).toBe(undefined);
+      });
+
+      it('passes desantized security ids to perform function', async () => {
+        await callResolver({
+          provider: {
+            test: {
+              security: {
+                foo__bar: { apikey: 'apikey' },
+              },
+            },
+          },
+        });
+
+        expect(performMock.mock.calls[0][1]['security']).toEqual({
+          'foo-bar': { apikey: 'apikey' },
+        });
       });
     });
 

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -42,7 +42,7 @@ import {
   pascalize,
   sanitize,
   sanitizeForGQLTypeName,
-  sanitizeProviderName,
+  sanitizeForFieldName,
   typeFromSafety,
 } from './schema.utils';
 import { ArrayMultiMap } from './structures';
@@ -288,7 +288,7 @@ export function generateProfileProviderOptionInputType(
   const providerFields: GraphQLInputFieldConfigMap = {};
 
   for (const providerName of providersNames) {
-    providerFields[sanitizeProviderName(providerName)] =
+    providerFields[sanitizeForFieldName(providerName)] =
       providerConfigTypeMap[providerName];
   }
 
@@ -411,7 +411,7 @@ export function generateUseCaseSecurityFields(
         );
       }
 
-      fields[schema.id] = {
+      fields[sanitizeForFieldName(schema.id)] = {
         description: `Security accepted by ${providerName}`,
         type,
       };

--- a/src/schema.utils.spec.ts
+++ b/src/schema.utils.spec.ts
@@ -2,13 +2,13 @@ import { GraphQLString } from 'graphql';
 import {
   camelize,
   capitalize,
-  desanitizeProviderName,
+  desanitizeForFieldName,
   description,
   hasFieldsDefined,
   pascalize,
   sanitize,
   sanitizedProfileName,
-  sanitizeProviderName,
+  sanitizeForFieldName,
   typeFromSafety,
 } from './schema.utils';
 
@@ -83,10 +83,10 @@ describe('schema.utils', () => {
     });
   });
 
-  describe('sanitizeProviderName + desanitizeProviderName', () => {
+  describe('sanitizeForFieldName + desanitizeForFieldName', () => {
     it('returns original provider name', () => {
       const provider = 'foo-bar_baz';
-      expect(desanitizeProviderName(sanitizeProviderName(provider))).toBe(
+      expect(desanitizeForFieldName(sanitizeForFieldName(provider))).toBe(
         provider,
       );
     });

--- a/src/schema.utils.ts
+++ b/src/schema.utils.ts
@@ -50,20 +50,17 @@ export function sanitizedProfileName(profileAst: ProfileDocumentNode): string {
 }
 
 /**
- * @param provider Provider name with characters: [a-z][a-z0-9_-]
- * @returns GQL valid field name representing provider name with characters: [_a-zA-Z][_a-zA-Z0-9]
- *
  * Sanitization can be reversed by desanitizeProviderName
  */
-export function sanitizeProviderName(provider: string): string {
-  return provider.replace(/-/g, '__');
+export function sanitizeForFieldName(input: string): string {
+  return input.replace(/-/g, '__');
 }
 
 /**
- * Inversed sanitizeProviderName
+ * Inversed sanitizeForFieldName
  */
-export function desanitizeProviderName(provider: string): string {
-  return provider.replace(/__/g, '-');
+export function desanitizeForFieldName(input: string): string {
+  return input.replace(/__/g, '-');
 }
 
 export function hasFieldsDefined(


### PR DESCRIPTION
Also, security ids, can contain `-`, so we need to sanitize and desanitize them. Similarly, as for provider name in https://github.com/superfaceai/one-service/pull/46