### PR TITLE
Fix mapping Comlink `number` primitive type to GraphQL `Float`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix mapping Comlink `number` primitive type to GraphQL `Float`  
 
 ## [3.0.1] - 2023-04-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix mapping Comlink `number` primitive type to GraphQL `Float`  
+- Fix mapping Comlink `number` primitive type to GraphQL `Float` - [#51](https://github.com/superfaceai/one-service/pull/51)
 
 ## [3.0.1] - 2023-04-03
 ### Fixed

--- a/src/__snapshots__/schema.spec.ts.snap
+++ b/src/__snapshots__/schema.spec.ts.snap
@@ -228,7 +228,7 @@ type ScopeNameMutation {
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameUnsafeUsecaseResult {
-  result: Int
+  result: Float
 }
 
 """Provider configuration for OneSDK perform"""
@@ -519,7 +519,7 @@ type ScopeNameMutation {
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameUnsafeUsecaseResult {
-  result: Int
+  result: Float
 }
 
 """Provider configuration for OneSDK perform"""

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -214,7 +214,7 @@ exports[`schema.types inputType returns GraphQLInputType 1`] = `
   Primitive
   Number
   """
-  primitive_number: Int
+  primitive_number: Float
 
   """
   Primitive
@@ -266,7 +266,7 @@ exports[`schema.types outputType returns GraphQLObjectType 1`] = `
   Primitive
   Number
   """
-  primitive_number: Int
+  primitive_number: Float
 
   """
   Primitive

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -21,11 +21,11 @@ import {
   GraphQLFieldConfig,
   GraphQLFieldConfigArgumentMap,
   GraphQLFieldConfigMap,
+  GraphQLFloat,
   GraphQLInputFieldConfig,
   GraphQLInputFieldConfigMap,
   GraphQLInputObjectType,
   GraphQLInputType,
-  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -473,7 +473,7 @@ export function primitiveType(
     case 'string':
       return GraphQLString; // http://spec.graphql.org/October2021/#sec-String
     case 'number':
-      return GraphQLInt; // http://spec.graphql.org/October2021/#sec-Int
+      return GraphQLFloat; // http://spec.graphql.org/October2021/#sec-Float
     case 'boolean':
       return GraphQLBoolean; // http://spec.graphql.org/October2021/#sec-Boolean
     default:


### PR DESCRIPTION
This PR fixes mapping Comlink `number` primitive type to GraphQL `Float`. Comlink number can be either integer or float.