### PR TITLE
Fix mapping empty objects to GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix mapping Comlink empty result structure and empty nested objects to GraphQL
-- Fix mapping Comlink empty nested objects in input to GraphQL
+- Map empty objects in result and input to custom types with noop field (`EmptyObject`, `EmptyInputObject`) - [#52](https://github.com/superfaceai/one-service/pull/52)
 
 ## [3.0.2] - 2023-04-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix mapping Comlink empty result structure to GraphQL
 
 ## [3.0.2] - 2023-04-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix mapping Comlink empty result structure to GraphQL
+- Fix mapping Comlink empty result structure and empty nested objects to GraphQL
+- Fix mapping Comlink empty nested objects in input to GraphQL
 
 ## [3.0.2] - 2023-04-05
 ### Fixed

--- a/src/__snapshots__/schema.spec.ts.snap
+++ b/src/__snapshots__/schema.spec.ts.snap
@@ -483,7 +483,12 @@ input TestDigestSecurityValues {
 }
 
 input ScopeNameUseCaseInput {
-  foo: None
+  foo: EmptyInput
+}
+
+"""Represents empty input object"""
+input EmptyInput {
+  _: None
 }
 
 """Represents NULL value"""
@@ -532,7 +537,12 @@ type ScopeNameUseCaseResult {
 }
 
 type ScopeNameUseCaseResultNode {
-  foo: None
+  foo: Empty
+}
+
+"""Represents empty object"""
+type Empty {
+  _: None
 }
 
 """Represents NULL value"""
@@ -631,7 +641,12 @@ type ScopeNameMutation {
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameUseCaseResult {
-  result: None
+  result: Empty
+}
+
+"""Represents empty object"""
+type Empty {
+  _: None
 }
 
 """Represents NULL value"""
@@ -730,7 +745,12 @@ type ScopeNameMutation {
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameNoResultResult {
-  result: None
+  result: Empty
+}
+
+"""Represents empty object"""
+type Empty {
+  _: None
 }
 
 """Represents NULL value"""

--- a/src/__snapshots__/schema.spec.ts.snap
+++ b/src/__snapshots__/schema.spec.ts.snap
@@ -382,6 +382,114 @@ input TestDigestSecurityValues {
 }"
 `;
 
+exports[`schema generate generates valid schema for usecase with empty nested object in input 1`] = `[]`;
+
+exports[`schema generate generates valid schema for usecase with empty nested object in input 2`] = `
+""""Superface.ai ❤️"""
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"""Profile's safe use-cases"""
+type Query {
+  _superJson: SuperJson
+}
+
+type SuperJson {
+  profiles: [ProfileInfo]
+  providers: [String]
+}
+
+type ProfileInfo {
+  name: String
+  version: String
+  providers: [String]
+}
+
+"""Profile's unsafe and idempotent use-cases"""
+type Mutation {
+  ScopeName: ScopeNameMutation
+}
+
+type ScopeNameMutation {
+  UseCase(
+    provider: ScopeNameProviderInput
+
+    """Use-case inputs"""
+    input: ScopeNameUseCaseInput
+  ): ScopeNameUseCaseResult
+}
+
+"""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameUseCaseResult {
+  result: String
+}
+
+"""Provider configuration for OneSDK perform"""
+input ScopeNameProviderInput {
+  """Provider test configuration"""
+  test: TestProviderConfig
+}
+
+input TestProviderConfig {
+  active: Boolean
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
+}
+
+"""Provider-specific parameters"""
+input TestProviderParameters {
+  """Parameter accepted by test"""
+  param_no_default: String
+
+  """Parameter accepted by test"""
+  param_default: String
+}
+
+"""Provider-specific security"""
+input TestProviderSecurity {
+  """Security accepted by test"""
+  api__key: TestApiKeySecurityValues
+
+  """Security accepted by test"""
+  basic: TestBasicSecurityValues
+
+  """Security accepted by test"""
+  bearer_token: TestBearerTokenSecurityValues
+
+  """Security accepted by test"""
+  digest: TestDigestSecurityValues
+}
+
+input TestApiKeySecurityValues {
+  apikey: String
+}
+
+input TestBasicSecurityValues {
+  username: String
+  password: String
+}
+
+input TestBearerTokenSecurityValues {
+  token: String
+}
+
+input TestDigestSecurityValues {
+  username: String
+  password: String
+}
+
+input ScopeNameUseCaseInput {
+  foo: None
+}
+
+"""Represents NULL value"""
+scalar None"
+`;
+
 exports[`schema generate generates valid schema for usecase with empty nested object in result 1`] = `[]`;
 
 exports[`schema generate generates valid schema for usecase with empty nested object in result 2`] = `

--- a/src/__snapshots__/schema.spec.ts.snap
+++ b/src/__snapshots__/schema.spec.ts.snap
@@ -382,6 +382,208 @@ input TestDigestSecurityValues {
 }"
 `;
 
+exports[`schema generate generates valid schema for usecase with empty nested object in result 1`] = `[]`;
+
+exports[`schema generate generates valid schema for usecase with empty nested object in result 2`] = `
+""""Superface.ai ❤️"""
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"""Profile's safe use-cases"""
+type Query {
+  _superJson: SuperJson
+}
+
+type SuperJson {
+  profiles: [ProfileInfo]
+  providers: [String]
+}
+
+type ProfileInfo {
+  name: String
+  version: String
+  providers: [String]
+}
+
+"""Profile's unsafe and idempotent use-cases"""
+type Mutation {
+  ScopeName: ScopeNameMutation
+}
+
+type ScopeNameMutation {
+  UseCase(provider: ScopeNameProviderInput): ScopeNameUseCaseResult
+}
+
+"""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameUseCaseResult {
+  result: ScopeNameUseCaseResultNode
+}
+
+type ScopeNameUseCaseResultNode {
+  foo: None
+}
+
+"""Represents NULL value"""
+scalar None
+
+"""Provider configuration for OneSDK perform"""
+input ScopeNameProviderInput {
+  """Provider test configuration"""
+  test: TestProviderConfig
+}
+
+input TestProviderConfig {
+  active: Boolean
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
+}
+
+"""Provider-specific parameters"""
+input TestProviderParameters {
+  """Parameter accepted by test"""
+  param_no_default: String
+
+  """Parameter accepted by test"""
+  param_default: String
+}
+
+"""Provider-specific security"""
+input TestProviderSecurity {
+  """Security accepted by test"""
+  api__key: TestApiKeySecurityValues
+
+  """Security accepted by test"""
+  basic: TestBasicSecurityValues
+
+  """Security accepted by test"""
+  bearer_token: TestBearerTokenSecurityValues
+
+  """Security accepted by test"""
+  digest: TestDigestSecurityValues
+}
+
+input TestApiKeySecurityValues {
+  apikey: String
+}
+
+input TestBasicSecurityValues {
+  username: String
+  password: String
+}
+
+input TestBearerTokenSecurityValues {
+  token: String
+}
+
+input TestDigestSecurityValues {
+  username: String
+  password: String
+}"
+`;
+
+exports[`schema generate generates valid schema for usecase with empty result 1`] = `[]`;
+
+exports[`schema generate generates valid schema for usecase with empty result 2`] = `
+""""Superface.ai ❤️"""
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+"""Profile's safe use-cases"""
+type Query {
+  _superJson: SuperJson
+}
+
+type SuperJson {
+  profiles: [ProfileInfo]
+  providers: [String]
+}
+
+type ProfileInfo {
+  name: String
+  version: String
+  providers: [String]
+}
+
+"""Profile's unsafe and idempotent use-cases"""
+type Mutation {
+  ScopeName: ScopeNameMutation
+}
+
+type ScopeNameMutation {
+  UseCase(provider: ScopeNameProviderInput): ScopeNameUseCaseResult
+}
+
+"""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameUseCaseResult {
+  result: None
+}
+
+"""Represents NULL value"""
+scalar None
+
+"""Provider configuration for OneSDK perform"""
+input ScopeNameProviderInput {
+  """Provider test configuration"""
+  test: TestProviderConfig
+}
+
+input TestProviderConfig {
+  active: Boolean
+  parameters: TestProviderParameters
+  security: TestProviderSecurity
+}
+
+"""Provider-specific parameters"""
+input TestProviderParameters {
+  """Parameter accepted by test"""
+  param_no_default: String
+
+  """Parameter accepted by test"""
+  param_default: String
+}
+
+"""Provider-specific security"""
+input TestProviderSecurity {
+  """Security accepted by test"""
+  api__key: TestApiKeySecurityValues
+
+  """Security accepted by test"""
+  basic: TestBasicSecurityValues
+
+  """Security accepted by test"""
+  bearer_token: TestBearerTokenSecurityValues
+
+  """Security accepted by test"""
+  digest: TestDigestSecurityValues
+}
+
+input TestApiKeySecurityValues {
+  apikey: String
+}
+
+input TestBasicSecurityValues {
+  username: String
+  password: String
+}
+
+input TestBearerTokenSecurityValues {
+  token: String
+}
+
+input TestDigestSecurityValues {
+  username: String
+  password: String
+}"
+`;
+
 exports[`schema generate generates valid schema for usecase without result 1`] = `[]`;
 
 exports[`schema generate generates valid schema for usecase without result 2`] = `

--- a/src/__snapshots__/schema.spec.ts.snap
+++ b/src/__snapshots__/schema.spec.ts.snap
@@ -483,11 +483,11 @@ input TestDigestSecurityValues {
 }
 
 input ScopeNameUseCaseInput {
-  foo: EmptyInput
+  foo: EmptyInputObject
 }
 
 """Represents empty input object"""
-input EmptyInput {
+input EmptyInputObject {
   _: None
 }
 
@@ -537,11 +537,11 @@ type ScopeNameUseCaseResult {
 }
 
 type ScopeNameUseCaseResultNode {
-  foo: Empty
+  foo: EmptyObject
 }
 
 """Represents empty object"""
-type Empty {
+type EmptyObject {
   _: None
 }
 
@@ -641,11 +641,11 @@ type ScopeNameMutation {
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameUseCaseResult {
-  result: Empty
+  result: EmptyObject
 }
 
 """Represents empty object"""
-type Empty {
+type EmptyObject {
   _: None
 }
 
@@ -745,11 +745,11 @@ type ScopeNameMutation {
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameNoResultResult {
-  result: Empty
+  result: EmptyObject
 }
 
 """Represents empty object"""
-type Empty {
+type EmptyObject {
   _: None
 }
 

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -118,6 +118,34 @@ type ScopeNameResult {
 scalar None"
 `;
 
+exports[`schema.types generateStructureResultType creates ScopeNameResult as None value if result is empty object 1`] = `
+""""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameResult {
+  result: None
+}
+
+"""Represents NULL value"""
+scalar None"
+`;
+
+exports[`schema.types generateStructureResultType creates ScopeNameResult if result contains nested empty object 1`] = `
+""""
+Wrapping type to handle many possible types returned as result by OneSDK
+"""
+type ScopeNameResult {
+  result: ScopeNameResultNode
+}
+
+type ScopeNameResultNode {
+  foo: None
+}
+
+"""Represents NULL value"""
+scalar None"
+`;
+
 exports[`schema.types generateStructureResultType creates ScopeNameResult with description and result field 1`] = `
 """"
 Wrapping type to handle many possible types returned as result by OneSDK

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -111,11 +111,11 @@ exports[`schema.types generateStructureResultType creates ScopeNameResult as Non
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameResult {
-  result: Empty
+  result: EmptyObject
 }
 
 """Represents empty object"""
-type Empty {
+type EmptyObject {
   _: None
 }
 
@@ -128,11 +128,11 @@ exports[`schema.types generateStructureResultType creates ScopeNameResult as Non
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameResult {
-  result: Empty
+  result: EmptyObject
 }
 
 """Represents empty object"""
-type Empty {
+type EmptyObject {
   _: None
 }
 
@@ -149,11 +149,11 @@ type ScopeNameResult {
 }
 
 type ScopeNameResultNode {
-  foo: Empty
+  foo: EmptyObject
 }
 
 """Represents empty object"""
-type Empty {
+type EmptyObject {
   _: None
 }
 

--- a/src/__snapshots__/schema.types.spec.ts.snap
+++ b/src/__snapshots__/schema.types.spec.ts.snap
@@ -111,7 +111,12 @@ exports[`schema.types generateStructureResultType creates ScopeNameResult as Non
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameResult {
-  result: None
+  result: Empty
+}
+
+"""Represents empty object"""
+type Empty {
+  _: None
 }
 
 """Represents NULL value"""
@@ -123,7 +128,12 @@ exports[`schema.types generateStructureResultType creates ScopeNameResult as Non
 Wrapping type to handle many possible types returned as result by OneSDK
 """
 type ScopeNameResult {
-  result: None
+  result: Empty
+}
+
+"""Represents empty object"""
+type Empty {
+  _: None
 }
 
 """Represents NULL value"""
@@ -139,7 +149,12 @@ type ScopeNameResult {
 }
 
 type ScopeNameResultNode {
-  foo: None
+  foo: Empty
+}
+
+"""Represents empty object"""
+type Empty {
+  _: None
 }
 
 """Represents NULL value"""

--- a/src/fixtures/profile_with_empty_nested_object_in_input.supr
+++ b/src/fixtures/profile_with_empty_nested_object_in_input.supr
@@ -1,0 +1,11 @@
+name = "scope/name"
+version = "1.0.0"
+
+usecase UseCase {
+  input {
+    foo {
+    }
+  }
+
+  result string
+}

--- a/src/fixtures/profile_with_empty_nested_object_in_result.supr
+++ b/src/fixtures/profile_with_empty_nested_object_in_result.supr
@@ -1,0 +1,10 @@
+name = "scope/name"
+version = "1.0.0"
+
+usecase UseCase {
+
+  result {
+    foo {
+    }
+  }
+}

--- a/src/fixtures/profile_with_empty_result.supr
+++ b/src/fixtures/profile_with_empty_result.supr
@@ -1,0 +1,8 @@
+name = "scope/name"
+version = "1.0.0"
+
+usecase UseCase {
+
+  result {
+  }
+}

--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -37,6 +37,14 @@ describe('schema', () => {
       expectSchema(schema);
     });
 
+    it('generates valid schema for usecase with empty nested object in input', async () => {
+      const schema = await generate(
+        await createSuperJson(['profile_with_empty_nested_object_in_input']),
+      );
+      expectSchemaValidationErrors(schema);
+      expectSchema(schema);
+    });
+
     it('generates valid schema for usecase with empty result', async () => {
       const schema = await generate(
         await createSuperJson(['profile_with_empty_result']),

--- a/src/schema.spec.ts
+++ b/src/schema.spec.ts
@@ -37,6 +37,22 @@ describe('schema', () => {
       expectSchema(schema);
     });
 
+    it('generates valid schema for usecase with empty result', async () => {
+      const schema = await generate(
+        await createSuperJson(['profile_with_empty_result']),
+      );
+      expectSchemaValidationErrors(schema);
+      expectSchema(schema);
+    });
+
+    it('generates valid schema for usecase with empty nested object in result', async () => {
+      const schema = await generate(
+        await createSuperJson(['profile_with_empty_nested_object_in_result']),
+      );
+      expectSchemaValidationErrors(schema);
+      expectSchema(schema);
+    });
+
     it('generates valid schema for usecase without result', async () => {
       const schema = await generate(await createSuperJson(['no_result']));
       expectSchemaValidationErrors(schema);

--- a/src/schema.types.spec.ts
+++ b/src/schema.types.spec.ts
@@ -293,6 +293,28 @@ describe('schema.types', () => {
         ),
       );
     });
+
+    it('creates ScopeNameResult as None value if result is empty object', async () => {
+      const profileOutput = await getProfileOutput('profile_with_empty_result');
+      expectSchema(
+        generateStructureResultType(
+          'ScopeNameResult',
+          profileOutput.usecases[0].result as StructureType,
+        ),
+      );
+    });
+
+    it('creates ScopeNameResult if result contains nested empty object', async () => {
+      const profileOutput = await getProfileOutput(
+        'profile_with_empty_nested_object_in_result',
+      );
+      expectSchema(
+        generateStructureResultType(
+          'ScopeNameResult',
+          profileOutput.usecases[0].result as StructureType,
+        ),
+      );
+    });
   });
 
   describe('prepareProviderConfigTypeMap', () => {

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -195,7 +195,11 @@ export function generateStructureResultType(
   debug(`generateStructureResultType for ${name} from structure`, structure);
 
   let type: GraphQLOutputType;
-  if (structure === undefined) {
+  if (
+    structure === undefined ||
+    (structure.kind === 'ObjectStructure' &&
+      Object.keys(structure.fields).length === 0)
+  ) {
     type = GraphQLNone;
   } else {
     type = outputType(`${name}Node`, structure);
@@ -545,10 +549,14 @@ export function outputType(
         },
       );
 
-      return new GraphQLObjectType({
-        name,
-        fields,
-      });
+      if (Object.keys(fields).length === 0) {
+        return GraphQLNone;
+      } else {
+        return new GraphQLObjectType({
+          name,
+          fields,
+        });
+      }
 
     case 'ListStructure':
       return new GraphQLList(outputType(name, structure.value));

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -601,6 +601,9 @@ export function inputType(
         },
       );
 
+      if (Object.keys(fields).length === 0) {
+        return GraphQLNone;
+      }
       return new GraphQLInputObjectType({
         name,
         fields,

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -200,7 +200,7 @@ export function generateStructureResultType(
     (structure.kind === 'ObjectStructure' &&
       Object.keys(structure.fields).length === 0)
   ) {
-    type = GraphQLNone;
+    type = GraphQLEmptyObject;
   } else {
     type = outputType(`${name}Node`, structure);
   }
@@ -550,7 +550,7 @@ export function outputType(
       );
 
       if (Object.keys(fields).length === 0) {
-        return GraphQLNone;
+        return GraphQLEmptyObject;
       } else {
         return new GraphQLObjectType({
           name,
@@ -602,7 +602,7 @@ export function inputType(
       );
 
       if (Object.keys(fields).length === 0) {
-        return GraphQLNone;
+        return GraphQLEmptyInputObject;
       }
       return new GraphQLInputObjectType({
         name,
@@ -635,5 +635,25 @@ export const GraphQLNone = new GraphQLScalarType({
 
   parseLiteral() {
     return null;
+  },
+});
+
+export const GraphQLEmptyObject = new GraphQLObjectType({
+  name: 'Empty',
+
+  description: 'Represents empty object',
+
+  fields: {
+    _: { type: GraphQLNone },
+  },
+});
+
+export const GraphQLEmptyInputObject = new GraphQLInputObjectType({
+  name: 'EmptyInput',
+
+  description: 'Represents empty input object',
+
+  fields: {
+    _: { type: GraphQLNone },
   },
 });

--- a/src/schema.types.ts
+++ b/src/schema.types.ts
@@ -639,7 +639,7 @@ export const GraphQLNone = new GraphQLScalarType({
 });
 
 export const GraphQLEmptyObject = new GraphQLObjectType({
-  name: 'Empty',
+  name: 'EmptyObject',
 
   description: 'Represents empty object',
 
@@ -649,7 +649,7 @@ export const GraphQLEmptyObject = new GraphQLObjectType({
 });
 
 export const GraphQLEmptyInputObject = new GraphQLInputObjectType({
-  name: 'EmptyInput',
+  name: 'EmptyInputObject',
 
   description: 'Represents empty input object',
 


### PR DESCRIPTION
This PR fixes mapping empty objects to GraphQL. GraphQL is more strict than Comlink and do not allow empty objects in GraphQL schema.

Empty objects can be part of Comlink input and result.

